### PR TITLE
feat: add support for schemas

### DIFF
--- a/src/SqlHelper.ts
+++ b/src/SqlHelper.ts
@@ -55,7 +55,7 @@ export function getSelectQueryAndParams<T extends Entity>({
     select,
   });
 
-  query += ` FROM "${model.tableName}"`;
+  query += ` FROM ${model.qualifiedTableName}`;
 
   const { whereStatement, params } = buildWhereStatement({
     repositoriesByModelNameLowered,
@@ -128,7 +128,7 @@ export function getCountQueryAndParams<T extends Entity>({
   model: ModelMetadata<T>;
   where?: WhereQuery<T>;
 }): QueryAndParams {
-  let query = `SELECT count(*) AS "count" FROM "${model.tableName}"`;
+  let query = `SELECT count(*) AS "count" FROM ${model.qualifiedTableName}`;
 
   const { whereStatement, params } = buildWhereStatement({
     repositoriesByModelNameLowered,
@@ -256,7 +256,7 @@ export function getInsertQueryAndParams<T extends Entity, K extends string & key
 
   const valueCollections: string[][] = entitiesToInsert.map(() => []);
   const params = [];
-  let query = `INSERT INTO "${model.tableName}" (`;
+  let query = `INSERT INTO ${model.qualifiedTableName} (`;
   for (const [columnIndex, column] of columnsToInsert.entries()) {
     if (columnIndex > 0) {
       query += ',';
@@ -428,7 +428,7 @@ export function getUpdateQueryAndParams<T extends Entity>({
   }
 
   const params = [];
-  let query = `UPDATE "${model.tableName}" SET `;
+  let query = `UPDATE ${model.qualifiedTableName} SET `;
   let isFirstProperty = true;
   for (const [propertyName, value] of Object.entries(values)) {
     const column = model.columnsByPropertyName[propertyName];
@@ -554,7 +554,7 @@ export function getDeleteQueryAndParams<T extends Entity>({
   returnRecords?: boolean;
   returnSelect?: readonly (string & keyof OmitFunctions<OmitEntityCollections<T>>)[];
 }): QueryAndParams {
-  let query = `DELETE FROM "${model.tableName}"`;
+  let query = `DELETE FROM ${model.qualifiedTableName}`;
 
   const { whereStatement, params } = buildWhereStatement({
     repositoriesByModelNameLowered,

--- a/src/decorators/TableOptions.ts
+++ b/src/decorators/TableOptions.ts
@@ -5,6 +5,11 @@ export interface TableOptions {
   name?: string;
 
   /**
+   * Schema table belongs to in the database
+   */
+  schema?: string;
+
+  /**
    * Connection name to use for queries
    */
   connection?: string;

--- a/src/decorators/table.ts
+++ b/src/decorators/table.ts
@@ -27,6 +27,7 @@ export function table<T extends Entity>(dbNameOrTableOptions?: TableOptions | st
     const metadataStorage = getMetadataStorage<T>();
     const modelMetadata = new ModelMetadata({
       name: className,
+      schema: options.schema,
       type: classObject,
       tableName: options.name,
       readonly: options.readonly ?? false,

--- a/src/metadata/ModelMetadata.ts
+++ b/src/metadata/ModelMetadata.ts
@@ -13,6 +13,7 @@ export interface ModelMetadataOptions<T extends Entity> {
   name: string;
   type: EntityStatic<T>;
   connection?: string;
+  schema?: string;
   tableName?: string;
   readonly?: boolean;
 }
@@ -75,11 +76,17 @@ export class ModelMetadata<T extends Entity> {
     return this._versionDateColumns;
   }
 
+  public get qualifiedTableName(): string {
+    return `${this.schema ? `"${this.schema}".` : ''}"${this.tableName}"`;
+  }
+
   public name: string;
 
   public type: EntityStatic<T>;
 
   public connection?: string;
+
+  public schema?: string;
 
   public tableName: string;
 
@@ -93,12 +100,14 @@ export class ModelMetadata<T extends Entity> {
     name, //
     type,
     connection,
+    schema,
     tableName,
     readonly = false,
   }: ModelMetadataOptions<T>) {
     this.name = name;
     this.type = type;
     this.connection = connection;
+    this.schema = schema;
     this.tableName = tableName ?? _.snakeCase(name);
     this.readonly = readonly;
   }

--- a/tests/models/SimpleWithSchema.ts
+++ b/tests/models/SimpleWithSchema.ts
@@ -1,0 +1,15 @@
+import { column, table } from '../../src/index.js';
+
+import { ModelBase } from './ModelBase.js';
+
+@table({
+  schema: 'foo',
+  name: 'simple',
+})
+export class SimpleWithSchema extends ModelBase {
+  @column({
+    type: 'string',
+    required: true,
+  })
+  public name!: string;
+}

--- a/tests/models/index.ts
+++ b/tests/models/index.ts
@@ -20,6 +20,7 @@ export * from './SimpleWithCreatedAtAndUpdatedAt.js';
 export * from './SimpleWithJson.js';
 export * from './SimpleWithOptionalEnum.js';
 export * from './SimpleWithRelationAndJson.js';
+export * from './SimpleWithSchema.js';
 export * from './SimpleWithSelfReference.js';
 export * from './SimpleWithStringCollection.js';
 export * from './SimpleWithStringId.js';

--- a/tests/sqlHelper.tests.ts
+++ b/tests/sqlHelper.tests.ts
@@ -151,7 +151,7 @@ describe('sqlHelper', () => {
         params.should.deep.equal([]);
       });
 
-      it('should schema if model specifies a schema', () => {
+      it('should include schema if specified for model', () => {
         const { query, params } = sqlHelper.getSelectQueryAndParams<SimpleWithSchema>({
           repositoriesByModelNameLowered,
           model: repositoriesByModelNameLowered.simplewithschema.model as ModelMetadata<SimpleWithSchema>,

--- a/tests/sqlHelper.tests.ts
+++ b/tests/sqlHelper.tests.ts
@@ -25,6 +25,7 @@ import {
   SimpleWithCreatedAt,
   SimpleWithCreatedAtAndUpdatedAt,
   SimpleWithJson,
+  SimpleWithSchema,
   SimpleWithStringId,
   SimpleWithUpdatedAt,
   SimpleWithUUID,
@@ -47,6 +48,7 @@ interface RepositoriesByModelName {
   SimpleWithCreatedAt: IRepository<Entity>;
   SimpleWithCreatedAtAndUpdatedAt: IRepository<Entity>;
   SimpleWithJson: IRepository<Entity>;
+  SimpleWithSchema: IRepository<Entity>;
   SimpleWithStringId: IRepository<Entity>;
   SimpleWithUpdatedAt: IRepository<Entity>;
   SimpleWithUUID: IRepository<Entity>;
@@ -81,6 +83,7 @@ describe('sqlHelper', () => {
         SimpleWithCreatedAt,
         SimpleWithCreatedAtAndUpdatedAt,
         SimpleWithJson,
+        SimpleWithSchema,
         SimpleWithStringId,
         SimpleWithUpdatedAt,
         SimpleWithUUID,
@@ -145,6 +148,21 @@ describe('sqlHelper', () => {
         });
 
         query.should.equal(`SELECT "name","id" FROM "${repositoriesByModelNameLowered.product.model.tableName}" LIMIT 1`);
+        params.should.deep.equal([]);
+      });
+
+      it('should schema if model specifies a schema', () => {
+        const { query, params } = sqlHelper.getSelectQueryAndParams<SimpleWithSchema>({
+          repositoriesByModelNameLowered,
+          model: repositoriesByModelNameLowered.simplewithschema.model as ModelMetadata<SimpleWithSchema>,
+          select: ['name'],
+          where: {},
+          sorts: [],
+          limit: 1,
+          skip: 0,
+        });
+
+        query.should.equal(`SELECT "name","id" FROM "${repositoriesByModelNameLowered.simplewithschema.model.schema}"."${repositoriesByModelNameLowered.simplewithschema.model.tableName}" LIMIT 1`);
         params.should.deep.equal([]);
       });
     });
@@ -256,6 +274,16 @@ describe('sqlHelper', () => {
 
       query.should.equal(`SELECT count(*) AS "count" FROM "${repositoriesByModelNameLowered.product.model.tableName}" WHERE "store_id"=$1`);
       params.should.deep.equal([store.id]);
+    });
+
+    it('should include schema if specified for model', () => {
+      const { query, params } = sqlHelper.getCountQueryAndParams({
+        repositoriesByModelNameLowered,
+        model: repositoriesByModelNameLowered.simplewithschema.model as ModelMetadata<SimpleWithSchema>,
+      });
+
+      query.should.equal(`SELECT count(*) AS "count" FROM "${repositoriesByModelNameLowered.simplewithschema.model.schema}"."${repositoriesByModelNameLowered.simplewithschema.model.tableName}"`);
+      params.should.deep.equal([]);
     });
   });
 
@@ -447,6 +475,21 @@ describe('sqlHelper', () => {
         `INSERT INTO "${repositoriesByModelNameLowered.product.model.tableName}" ("name","alias_names","store_id") VALUES ($1,$2,$3) RETURNING "id","name","sku","location","alias_names" AS "aliases","store_id" AS "store"`,
       );
       params.should.deep.equal([name, [], store.id]);
+    });
+
+    it('should include schema if specified for model', () => {
+      const name = faker.string.uuid();
+      const { query } = sqlHelper.getInsertQueryAndParams({
+        repositoriesByModelNameLowered,
+        model: repositoriesByModelNameLowered.simplewithschema.model as ModelMetadata<SimpleWithSchema>,
+        values: {
+          name,
+        },
+      });
+
+      query.should.equal(
+        `INSERT INTO "${repositoriesByModelNameLowered.simplewithschema.model.schema}"."${repositoriesByModelNameLowered.simplewithschema.model.tableName}" ("name") VALUES ($1) RETURNING "id","name"`,
+      );
     });
 
     it('should cast value to jsonb if type=json and value is an array', () => {
@@ -1185,6 +1228,22 @@ describe('sqlHelper', () => {
       params.should.deep.equal([name, store.id]);
     });
 
+    it('should include schema if specified for model', () => {
+      const name = faker.string.uuid();
+      const { query } = sqlHelper.getUpdateQueryAndParams({
+        repositoriesByModelNameLowered,
+        model: repositoriesByModelNameLowered.simplewithschema.model as ModelMetadata<SimpleWithSchema>,
+        where: {},
+        values: {
+          name,
+        },
+      });
+
+      query.should.equal(
+        `UPDATE "${repositoriesByModelNameLowered.simplewithschema.model.schema}"."${repositoriesByModelNameLowered.simplewithschema.model.tableName}" SET "name"=$1 RETURNING "id","name"`,
+      );
+    });
+
     it('should cast value to jsonb if type=json and value is an array', () => {
       // Please see https://github.com/brianc/node-postgres/issues/442 for details of why this is needed
       const name = faker.string.uuid();
@@ -1512,6 +1571,15 @@ describe('sqlHelper', () => {
         `DELETE FROM "${repositoriesByModelNameLowered.productwithcreatedat.model.tableName}" WHERE "store_id"=$1 RETURNING "id","name","sku","location","alias_names" AS "aliases","store_id" AS "store","created_at" AS "createdAt"`,
       );
       params.should.deep.equal([store.id]);
+    });
+
+    it('should include schema if specified for model', () => {
+      const { query } = sqlHelper.getDeleteQueryAndParams({
+        repositoriesByModelNameLowered,
+        model: repositoriesByModelNameLowered.simplewithschema.model as ModelMetadata<SimpleWithSchema>,
+      });
+
+      query.should.equal(`DELETE FROM "${repositoriesByModelNameLowered.simplewithschema.model.schema}"."${repositoriesByModelNameLowered.simplewithschema.model.tableName}" RETURNING "id","name"`);
     });
 
     it('should return records if returnRecords=true', () => {


### PR DESCRIPTION
thought a naive `{ table: 'schema.table' }` config would work, but the generated sql `"schema.table"` is invalid - need explict `"schema"."table"`