### PR TITLE
feat!: Remove Node.js v18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['18', '20', '22']
+        node-version: ['20', '22', '24']
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/bigalorm/bigal#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.11.0"
   },
   "dependencies": {
     "@types/pg": "8.15.1",


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Node.js v18. Minimum required version is now Node.js v20.

- Updated engines field in package.json
- Updated CI configuration to test on supported versions only