### PR TITLE
fix: Return Pick<QueryResult<T>> from chained .select()

### DIFF
--- a/src/ReadonlyRepository.ts
+++ b/src/ReadonlyRepository.ts
@@ -157,10 +157,10 @@ export class ReadonlyRepository<T extends Entity> implements IReadonlyRepository
        * @param {string[]} keys - Columns to select from the entity
        * @returns Query instance
        */
-      select<TKeys extends string & keyof T>(keys: TKeys[]): FindOneResult<T, Pick<T, TKeys>> {
+      select<TKeys extends string & keyof OmitFunctions<QueryResult<T>>>(keys: TKeys[]): FindOneResult<T, Pick<QueryResult<T>, TKeys>> {
         select = new Set(keys);
-        // TypeScript cast for chaining - this is safe as per FindResult generic contract
-        return this as unknown as FindOneResult<T, Pick<T, TKeys>>;
+        // TypeScript cast for chaining - this is safe as per FindOneResult generic contract
+        return this as unknown as FindOneResult<T, Pick<QueryResult<T>, TKeys>>;
       },
       /**
        * Filters the query
@@ -389,10 +389,10 @@ export class ReadonlyRepository<T extends Entity> implements IReadonlyRepository
        * @param {string[]} keys - Columns to select from the entity
        * @returns Query instance
        */
-      select<TKeys extends string & keyof T>(keys: TKeys[]): FindResult<T, Pick<T, TKeys>> {
+      select<TKeys extends string & keyof OmitFunctions<QueryResult<T>>>(keys: TKeys[]): FindResult<T, Pick<QueryResult<T>, TKeys>> {
         select = new Set(keys);
         // TypeScript cast for chaining - this is safe as per FindResult generic contract
-        return this as unknown as FindResult<T, Pick<T, TKeys>>;
+        return this as unknown as FindResult<T, Pick<QueryResult<T>, TKeys>>;
       },
       /**
        * Filters the query

--- a/src/query/FindOneResult.ts
+++ b/src/query/FindOneResult.ts
@@ -1,5 +1,5 @@
 import type { Entity } from '../Entity.js';
-import type { GetValueType, ModelRelationshipKeys, PickAsType, PickByValueType, PlainObject, Populated } from '../types/index.js';
+import type { GetValueType, ModelRelationshipKeys, OmitFunctions, PickAsType, PickByValueType, PlainObject, Populated, QueryResult } from '../types/index.js';
 
 import type { JoinedSort } from './JoinedSort.js';
 import type { JoinedWhereQuery, JoinInfo } from './JoinedWhereQuery.js';
@@ -7,7 +7,7 @@ import type { PopulateArgs } from './PopulateArgs.js';
 import type { WhereQuery } from './WhereQuery.js';
 
 export interface FindOneResultJSON<T extends Entity, TReturn, TJoins extends JoinInfo = never> extends PromiseLike<PlainObject<TReturn> | null> {
-  select<TKeys extends string & keyof T>(keys: TKeys[]): FindOneResultJSON<T, Pick<T, TKeys>, TJoins>;
+  select<TKeys extends string & keyof OmitFunctions<QueryResult<T>>>(keys: TKeys[]): FindOneResultJSON<T, Pick<QueryResult<T>, TKeys>, TJoins>;
   where(args: JoinedWhereQuery<T, TJoins>): FindOneResultJSON<T, TReturn, TJoins>;
   populate<TProperty extends string & keyof PickByValueType<T, Entity> & keyof T, TPopulateType extends GetValueType<T[TProperty], Entity>, TPopulateSelectKeys extends string & keyof TPopulateType>(
     propertyName: TProperty,
@@ -33,7 +33,7 @@ export interface FindOneResultJSON<T extends Entity, TReturn, TJoins extends Joi
 }
 
 export interface FindOneResult<T extends Entity, TReturn, TJoins extends JoinInfo = never> extends PromiseLike<TReturn | null> {
-  select<TKeys extends string & keyof T>(keys: TKeys[]): FindOneResult<T, Pick<T, TKeys>, TJoins>;
+  select<TKeys extends string & keyof OmitFunctions<QueryResult<T>>>(keys: TKeys[]): FindOneResult<T, Pick<QueryResult<T>, TKeys>, TJoins>;
   where(args: JoinedWhereQuery<T, TJoins>): FindOneResult<T, TReturn, TJoins>;
   populate<TProperty extends string & keyof PickByValueType<T, Entity> & keyof T, TPopulateType extends GetValueType<T[TProperty], Entity>, TPopulateSelectKeys extends string & keyof TPopulateType>(
     propertyName: TProperty,

--- a/src/query/FindResult.ts
+++ b/src/query/FindResult.ts
@@ -1,5 +1,5 @@
 import type { Entity } from '../Entity.js';
-import type { GetValueType, ModelRelationshipKeys, OmitEntityCollections, OmitFunctions, PickByValueType, PlainObject, Populated } from '../types/index.js';
+import type { GetValueType, ModelRelationshipKeys, OmitEntityCollections, OmitFunctions, PickByValueType, PlainObject, Populated, QueryResult } from '../types/index.js';
 
 import type { FindQueryWithCount, FindQueryWithCountJSON } from './FindWithCountResult.js';
 import type { SubqueryJoinOnCondition } from './JoinDefinition.js';
@@ -13,7 +13,7 @@ import type { WhereQuery } from './WhereQuery.js';
 // WhereQuery is used for leftJoin 'on' condition
 
 export interface FindResultJSON<T extends Entity, TReturn, TJoins extends AnyJoinInfo = never> extends PromiseLike<PlainObject<TReturn>[]> {
-  select<TKeys extends string & keyof T>(keys: TKeys[]): FindResultJSON<T, Pick<T, TKeys>, TJoins>;
+  select<TKeys extends string & keyof OmitFunctions<QueryResult<T>>>(keys: TKeys[]): FindResultJSON<T, Pick<QueryResult<T>, TKeys>, TJoins>;
   where(args: JoinedWhereQuery<T, TJoins>): FindResultJSON<T, TReturn, TJoins>;
   populate<TProperty extends string & keyof PickByValueType<T, Entity> & keyof T, TPopulateType extends GetValueType<T[TProperty], Entity>, TPopulateSelectKeys extends string & keyof TPopulateType>(
     propertyName: TProperty,
@@ -75,7 +75,7 @@ export interface FindResultJSON<T extends Entity, TReturn, TJoins extends AnyJoi
 }
 
 export interface FindResult<T extends Entity, TReturn, TJoins extends AnyJoinInfo = never> extends PromiseLike<TReturn[]> {
-  select<TKeys extends string & keyof T>(keys: TKeys[]): FindResult<T, Pick<T, TKeys>, TJoins>;
+  select<TKeys extends string & keyof OmitFunctions<QueryResult<T>>>(keys: TKeys[]): FindResult<T, Pick<QueryResult<T>, TKeys>, TJoins>;
   where(args: JoinedWhereQuery<T, TJoins>): FindResult<T, TReturn, TJoins>;
   populate<TProperty extends string & keyof PickByValueType<T, Entity> & keyof T, TPopulateType extends GetValueType<T[TProperty], Entity>, TPopulateSelectKeys extends string & keyof TPopulateType>(
     propertyName: TProperty,

--- a/src/query/FindWithCountResult.ts
+++ b/src/query/FindWithCountResult.ts
@@ -1,5 +1,5 @@
 import type { Entity } from '../Entity.js';
-import type { GetValueType, ModelRelationshipKeys, PickByValueType, PlainObject, Populated } from '../types/index.js';
+import type { GetValueType, ModelRelationshipKeys, OmitFunctions, PickByValueType, PlainObject, Populated, QueryResult } from '../types/index.js';
 
 import type { SubqueryJoinOnCondition } from './JoinDefinition.js';
 import type { AnyJoinInfo, JoinedSort } from './JoinedSort.js';
@@ -15,7 +15,7 @@ export interface FindWithCountResult<TReturn> {
 }
 
 export interface FindQueryWithCountJSON<T extends Entity, TReturn, TJoins extends AnyJoinInfo = never> extends PromiseLike<FindWithCountResult<PlainObject<TReturn>>> {
-  select<TKeys extends string & keyof T>(keys: TKeys[]): FindQueryWithCountJSON<T, Pick<T, TKeys>, TJoins>;
+  select<TKeys extends string & keyof OmitFunctions<QueryResult<T>>>(keys: TKeys[]): FindQueryWithCountJSON<T, Pick<QueryResult<T>, TKeys>, TJoins>;
   where(args: JoinedWhereQuery<T, TJoins>): FindQueryWithCountJSON<T, TReturn, TJoins>;
   populate<TProperty extends string & keyof PickByValueType<T, Entity> & keyof T, TPopulateType extends GetValueType<T[TProperty], Entity>, TPopulateSelectKeys extends string & keyof TPopulateType>(
     propertyName: TProperty,
@@ -49,7 +49,7 @@ export interface FindQueryWithCountJSON<T extends Entity, TReturn, TJoins extend
 }
 
 export interface FindQueryWithCount<T extends Entity, TReturn, TJoins extends AnyJoinInfo = never> extends PromiseLike<FindWithCountResult<TReturn>> {
-  select<TKeys extends string & keyof T>(keys: TKeys[]): FindQueryWithCount<T, Pick<T, TKeys>, TJoins>;
+  select<TKeys extends string & keyof OmitFunctions<QueryResult<T>>>(keys: TKeys[]): FindQueryWithCount<T, Pick<QueryResult<T>, TKeys>, TJoins>;
   where(args: JoinedWhereQuery<T, TJoins>): FindQueryWithCount<T, TReturn, TJoins>;
   populate<TProperty extends string & keyof PickByValueType<T, Entity> & keyof T, TPopulateType extends GetValueType<T[TProperty], Entity>, TPopulateSelectKeys extends string & keyof TPopulateType>(
     propertyName: TProperty,

--- a/tests/readonlyRepository.test.ts
+++ b/tests/readonlyRepository.test.ts
@@ -2257,6 +2257,27 @@ describe('ReadonlyRepository', () => {
       expect(params).toStrictEqual([]);
     });
 
+    it('should compose chained select() and populate() (select narrows columns; populate hydrates the FK)', async () => {
+      const productResult = pick(generator.product({ store: store.id }), 'id', 'name', 'store');
+      const storeResult = pick(store, 'id', 'name');
+      mockedPool.query.mockResolvedValueOnce(getQueryResult([productResult])).mockResolvedValueOnce(getQueryResult([storeResult]));
+
+      const [result] = await ProductRepository.find().select(['name', 'store']).populate('store');
+      assert(result);
+      // eslint-disable-next-line vitest-js/prefer-strict-equal
+      expect(result).toEqual({
+        ...productResult,
+        store: storeResult,
+      });
+
+      const [productQuery] = mockedPool.query.mock.calls[0]!;
+      // Select query must include the FK column (`store_id` AS `store`) so populate has the join key.
+      expect(productQuery).toBe('SELECT "name","store_id" AS "store","id" FROM "products"');
+      const [storeQuery, storeQueryParams] = mockedPool.query.mock.calls[1]!;
+      expect(storeQuery).toBe('SELECT "id","name" FROM "stores" WHERE "id"=$1');
+      expect(storeQueryParams).toStrictEqual([store.id]);
+    });
+
     describe('join', () => {
       it('should support inner join with nested where clause', async () => {
         const products = [

--- a/tests/typeVariance.test.ts
+++ b/tests/typeVariance.test.ts
@@ -1,15 +1,23 @@
 import { describe, it } from 'vitest';
 
-import type { IReadonlyRepository, IRepository, WhereQuery } from '../src/index.js';
+import type { IReadonlyRepository, IRepository, QueryResult, WhereQuery } from '../src/index.js';
+import type { FindOneResult, FindResult } from '../src/query/index.js';
 
 import type { ModelBase } from './models/ModelBase.js';
 import type { Product } from './models/Product.js';
 import type { SimpleWithJson } from './models/SimpleWithJson.js';
+import type { Store } from './models/Store.js';
 
 // Compile-time assignability checks - a type error means variance is broken
 function acceptWhereQuery(_where: WhereQuery<ModelBase>): void {}
 function acceptReadonlyRepository(_repo: IReadonlyRepository<ModelBase>): void {}
 function acceptRepository(_repo: IRepository<ModelBase>): void {}
+
+// Exact-equality helper for type-level assertions. Resolves to `true` only when X and Y are
+// structurally identical, so a type error here means the inferred type drifted.
+type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+// `T` is consumed by the optional param so lint sees it as used; passing the param is unnecessary.
+function assertExact<T extends true>(_check?: T): void {}
 
 describe('Type variance', () => {
   it('should allow WhereQuery<SpecificModel> where WhereQuery<BaseModel> is expected', () => {
@@ -40,5 +48,98 @@ describe('Type variance', () => {
   it('should allow IRepository<ModelWithJsonColumn> where IRepository<BaseModel> is expected', () => {
     const repo = {} as IRepository<SimpleWithJson>;
     acceptRepository(repo);
+  });
+});
+
+// Product.store is `Store | number`. After `.select(['store'])` the result must reflect what
+// SQL actually returns: the foreign-key primitive, never the populated `Store` instance.
+// This caught a real bug where `.select()` returned `Pick<T, K>` (carrying `Store | number`)
+// instead of `Pick<QueryResult<T>, K>` (yielding just `number`).
+//
+// These checks run at compile time only. The function is never invoked at runtime (the repo
+// values are empty objects with the wrong shape), but tsgo still type-checks the body. Any
+// drift in `.select()`'s return type or constraints produces a compile error here.
+async function _selectReturnTypeChecks(productRepo: IRepository<Product>, storeRepo: IRepository<Store>): Promise<void> {
+  // findOne().select() — entity ref column becomes the FK primitive in the result.
+  {
+    const result = await productRepo.findOne({}).select(['name', 'store']);
+    type Actual = typeof result;
+    type Expected = Pick<QueryResult<Product>, 'name' | 'store'> | null;
+    assertExact<Equals<Actual, Expected>>();
+  }
+
+  // find().select() — same shape, wrapped in array.
+  {
+    const result = await productRepo.find({}).select(['store']);
+    type Actual = typeof result;
+    type Expected = Pick<QueryResult<Product>, 'store'>[];
+    assertExact<Equals<Actual, Expected>>();
+  }
+
+  // Direct assignability against the result interfaces — any drift in the generic produces
+  // a compile error here.
+  {
+    const findOneSelect: FindOneResult<Product, Pick<QueryResult<Product>, 'name'>> = productRepo.findOne({}).select(['name']);
+    const findSelect: FindResult<Product, Pick<QueryResult<Product>, 'name'>> = productRepo.find({}).select(['name']);
+    void findOneSelect;
+    void findSelect;
+  }
+
+  // toJSON() after select() preserves the QueryResult-flavored shape.
+  {
+    const findOneJson = await productRepo.findOne({}).select(['store']).toJSON();
+    const findJson = await productRepo.find({}).select(['store']).toJSON();
+    if (findOneJson !== null) {
+      const storeFk: number = findOneJson.store;
+      void storeFk;
+    }
+    const firstStoreFk: number | undefined = findJson[0]?.store;
+    void firstStoreFk;
+  }
+
+  // select() rejects collection-typed properties — selecting them makes no sense (no SQL
+  // column) and they are stripped from QueryResult.
+  // @ts-expect-error - 'categories' is a collection and must not be selectable
+  productRepo.find({}).select(['categories']);
+  // @ts-expect-error - same constraint on findOne
+  productRepo.findOne({}).select(['categories']);
+  // @ts-expect-error - and on Store.products (the inverse side)
+  storeRepo.find({}).select(['products']);
+
+  // select() then populate() composes: the populated property must be assignable to Store,
+  // not the FK primitive.
+  {
+    const [row] = await productRepo.find({}).select(['name', 'store']).populate('store');
+    if (row) {
+      const storeId: number = row.store.id;
+      const storeName: string | undefined = row.store.name;
+      // `name` (a primitive column) keeps its narrowed type from the select.
+      const productName: string = row.name;
+      void storeId;
+      void storeName;
+      void productName;
+    }
+  }
+
+  // Regression guard: `.select()` alone must NOT carry the Store entity. Pre-fix, the union
+  // `Store | number` survived and a Store instance was accepted at the call site.
+  {
+    const result = await productRepo.findOne({}).select(['store']);
+    if (result) {
+      const fk: number = result.store;
+      // @ts-expect-error - `store` after select() must NOT carry the Store entity
+      const asStore: Store = result.store;
+      void fk;
+      void asStore;
+    }
+  }
+}
+
+describe('select() return type', () => {
+  it('compile-time checks for select() return type and select+populate composition', () => {
+    // The actual type assertions live in `_selectReturnTypeChecks` above. tsgo verifies them
+    // during `npm run check:types`; this test exists so vitest reports the suite passing and
+    // surfaces any failure in test output.
+    void _selectReturnTypeChecks;
   });
 });


### PR DESCRIPTION
The fluent .select() on FindResult, FindOneResult, and FindQueryWithCount returned Pick<T, K>, which preserved Entity-typed columns (e.g. `Store | number`) even though SQL only loads the FK primitive. The args-style `findOne({select})` already wraps in QueryResult<>, so the two paths disagreed.

Tighten the keys constraint to `keyof OmitFunctions<QueryResult<T>>` so that collection-typed properties (stripped from QueryResult) and methods are rejected at compile time, and return Pick<QueryResult<T>, K> so the type matches the shape `_buildInstance` actually produces. populate() composes correctly because its `Omit<TReturn, P> & Populated<...>` runs over the already-narrowed select return.