### PR TITLE
fix: prevent propertyName leak across where-clause iteration

### DIFF
--- a/src/SqlHelper.ts
+++ b/src/SqlHelper.ts
@@ -1630,34 +1630,35 @@ function buildWhere<T extends Entity>({
 
           // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
           let subQueryComparer: Comparer | string | undefined;
+          let iterationPropertyName = propertyName;
           if (isComparer(key)) {
             subQueryComparer = key;
-          } else if (propertyName) {
-            const parentColumn = model.columnsByPropertyName[propertyName] as ColumnTypeMetadata;
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            if (parentColumn?.type?.toLowerCase() === 'json') {
-              andValues.push(
-                buildJsonPropertyClause({
-                  columnName: parentColumn.name,
-                  path: [key],
-                  isNegated,
-                  constraint: where,
-                  params,
-                }),
-              );
-              continue;
+          } else {
+            if (propertyName) {
+              const parentColumn = model.columnsByPropertyName[propertyName] as ColumnTypeMetadata;
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+              if (parentColumn?.type?.toLowerCase() === 'json') {
+                andValues.push(
+                  buildJsonPropertyClause({
+                    columnName: parentColumn.name,
+                    path: [key],
+                    isNegated,
+                    constraint: where,
+                    params,
+                  }),
+                );
+                continue;
+              }
             }
 
-            propertyName = key;
-          } else {
-            propertyName = key;
+            iterationPropertyName = key;
           }
 
           andValues.push(
             buildWhere({
               repositoriesByModelNameLowered,
               model,
-              propertyName,
+              propertyName: iterationPropertyName,
               comparer: subQueryComparer,
               isNegated,
               value: where as WhereClauseValue<T>,

--- a/tests/sqlHelper.test.ts
+++ b/tests/sqlHelper.test.ts
@@ -5,7 +5,18 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { QueryError } from '../src/errors/index.js';
 import { initialize, subquery } from '../src/index.js';
-import { type AggregateBuilder, type Entity, type IReadonlyRepository, type IRepository, type ModelMetadata, type PoolLike, type SelectAggregateExpression, type WhereQuery } from '../src/index.js';
+import {
+  type AggregateBuilder,
+  type Entity,
+  type IReadonlyRepository,
+  type IRepository,
+  type ModelMetadata,
+  type PoolLike,
+  type PoolQueryResult,
+  type QueryResultRow,
+  type SelectAggregateExpression,
+  type WhereQuery,
+} from '../src/index.js';
 import * as sqlHelper from '../src/SqlHelper.js';
 
 import {
@@ -56,12 +67,14 @@ interface RepositoriesByModelName {
 
 type LowerCaseKeys<T, K extends string & keyof T = string & keyof T> = Record<Lowercase<K>, T[K]>;
 
+type MockedPoolQuery = (text: string, values?: readonly unknown[]) => Promise<PoolQueryResult<QueryResultRow>>;
+
 describe('sqlHelper', () => {
   let repositoriesByModelName: RepositoriesByModelName;
   const repositoriesByModelNameLowered = {} as LowerCaseKeys<RepositoriesByModelName>;
 
   beforeAll(() => {
-    const mockedPool: PoolLike = { query: vi.fn() };
+    const mockedPool: PoolLike = { query: vi.fn<MockedPoolQuery>() } as unknown as PoolLike;
     repositoriesByModelName = initialize({
       models: [
         Category,
@@ -2702,6 +2715,36 @@ describe('sqlHelper', () => {
         assert(whereStatement);
         expect(whereStatement).toBe(`WHERE "bar"->'failure'->>'stage'=$1 AND ("bar"->'failure'->>'code')::numeric>=$2`);
         expect(params).toStrictEqual(['transcription', 400]);
+      });
+
+      it('should not treat a sibling top-level column as a JSON path of a prior JSON column', () => {
+        const { whereStatement, params } = sqlHelper.buildWhereStatement({
+          repositoriesByModelNameLowered,
+          model: repositoriesByModelNameLowered.simplewithjson.model as ModelMetadata<SimpleWithJson>,
+          where: {
+            bar: { '!': '{}' },
+            name: 'pizza',
+          } as WhereQuery<SimpleWithJson>,
+        });
+
+        assert(whereStatement);
+        expect(whereStatement).toBe(`WHERE "bar"<>$1 AND "name"=$2`);
+        expect(params).toStrictEqual(['{}', 'pizza']);
+      });
+
+      it('should not treat a sibling top-level column following a JSON path query as another path on the JSON column', () => {
+        const { whereStatement, params } = sqlHelper.buildWhereStatement({
+          repositoriesByModelNameLowered,
+          model: repositoriesByModelNameLowered.simplewithjson.model as ModelMetadata<SimpleWithJson>,
+          where: {
+            bar: { theme: 'dark' },
+            name: 'pizza',
+          } as WhereQuery<SimpleWithJson>,
+        });
+
+        assert(whereStatement);
+        expect(whereStatement).toBe(`WHERE "bar"->>'theme'=$1 AND "name"=$2`);
+        expect(params).toStrictEqual(['dark', 'pizza']);
       });
     });
 


### PR DESCRIPTION
## Summary

- Fixes #393: a `.where({...})` clause that mixed a JSON-column condition with sibling non-JSON columns produced SQL where the non-JSON columns were rewritten as JSON paths on the prior JSON column (e.g. `"message"->>'type'=$3` instead of `"type"=$3`).
- Root cause: `buildWhere` in `src/SqlHelper.ts` mutated the outer `propertyName` parameter while iterating the where object's keys, so the previous iteration's column name leaked into the next iteration's JSON-path branch.
- Fix: use a per-iteration `iterationPropertyName` local; never mutate the outer `propertyName` parameter.

## Test plan

- [x] Added two failing-then-passing tests in `tests/sqlHelper.test.ts` covering both an inequality on a JSON column followed by a non-JSON sibling, and a JSON path query followed by a non-JSON sibling.
- [x] `npm test` (all 472 tests pass, including the two new tests)
- [x] `npm run check:types`
- [x] `npx oxlint --fix --fix-suggestions --deny-warnings src/SqlHelper.ts tests/sqlHelper.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)