### PR TITLE
fix: qualify base-table columns when a query has a join

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/docs/guide/subqueries-and-joins.md
+++ b/docs/guide/subqueries-and-joins.md
@@ -96,9 +96,9 @@ const products = await productRepository
   .find()
   .join('store')
   .where({ store: { name: 'Acme' } });
-// SQL: SELECT "products".* FROM "products"
-//   INNER JOIN "stores" ON "products"."store_id"="stores"."id"
-//   WHERE "stores"."name"=$1
+// SQL: SELECT "products"."id","products"."name",… FROM "products"
+//   INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id"
+//   WHERE "store"."name"=$1
 
 // Left join
 const products = await productRepository
@@ -116,6 +116,9 @@ const products = await productRepository
 const products = await productRepository.find().leftJoin('store', 'activeStore', { isActive: true });
 ```
 
+When a query includes any join, BigAl automatically qualifies the base table's own columns (in `SELECT`, `WHERE`, `ORDER BY`, and `DISTINCT ON`) with the base table name.
+This keeps columns that share a name across the base and joined tables (most commonly `id`) from being ambiguous, so `.join()` is safe to use without falling back to raw SQL.
+
 ## Subquery joins
 
 Join to subquery results:
@@ -127,7 +130,7 @@ const productCounts = subquery(productRepository)
 
 // Inner join
 const stores = await storeRepository.find().join(productCounts, 'stats', { on: { id: 'store' } });
-// SQL: SELECT "stores".* FROM "stores"
+// SQL: SELECT "stores"."id","stores"."name" FROM "stores"
 //   INNER JOIN (
 //     SELECT "store_id" AS "store", COUNT(*) AS "productCount"
 //     FROM "products" GROUP BY "store_id"

--- a/src/SqlHelper.ts
+++ b/src/SqlHelper.ts
@@ -20,6 +20,18 @@ function assertValidSqlIdentifier(value: string, context: string): void {
   }
 }
 
+/**
+ * Returns the SQL prefix used to qualify base-table columns. When a query has one or more joins, base-table columns must be qualified to avoid ambiguity with columns of the same name on a joined
+ * table. Join-less queries return an empty prefix so their SQL is unchanged.
+ * @param {object} model - Model schema for the base table
+ * @param {JoinDefinition[]} [joins] - Array of join definitions for the query
+ * @returns {string} The qualified table prefix (e.g. `"schema"."table".`) when joins are present, otherwise an empty string
+ * @private
+ */
+function getBaseColumnPrefix<T extends Entity>(model: ModelMetadata<T>, joins?: readonly JoinDefinition[]): string {
+  return joins?.length ? `${model.qualifiedTableName}.` : '';
+}
+
 interface QueryAndParams {
   query: string;
   params: readonly unknown[];
@@ -101,13 +113,14 @@ export function getSelectQueryAndParams<T extends Entity>({
   let query = 'SELECT ';
 
   if (distinctOn?.length) {
+    const baseColumnPrefix = getBaseColumnPrefix(model, joins);
     const distinctOnColumnNames = distinctOn.map((propertyName) => {
       const column = model.columnsByPropertyName[propertyName];
       if (!column) {
         throw new QueryError(`Unable to find column for DISTINCT ON property: ${propertyName} on ${model.tableName}`, model);
       }
 
-      return `"${column.name}"`;
+      return `${baseColumnPrefix}"${column.name}"`;
     });
     query += `DISTINCT ON (${distinctOnColumnNames.join(',')}) `;
   }
@@ -115,6 +128,7 @@ export function getSelectQueryAndParams<T extends Entity>({
   query += getColumnsToSelect({
     model,
     select,
+    joins,
   });
 
   if (includeCount) {
@@ -666,6 +680,7 @@ export function getDeleteQueryAndParams<T extends Entity>({
  * @param {object} args - Arguments
  * @param {object} args.model - Model schema
  * @param {string[]} [args.select] - Array of model property names to return from the query.
+ * @param {JoinDefinition[]} [args.joins] - Array of join definitions. When present, base-table columns are qualified to avoid ambiguity with joined tables.
  * @returns {string} SQL columns
  * @private
  */
@@ -673,9 +688,11 @@ export function getDeleteQueryAndParams<T extends Entity>({
 export function getColumnsToSelect<T extends Entity, K extends string & keyof OmitFunctions<OmitEntityCollections<T>> = string & keyof OmitFunctions<OmitEntityCollections<T>>>({
   model,
   select,
+  joins,
 }: {
   model: ModelMetadata<T>;
   select?: readonly K[];
+  joins?: readonly JoinDefinition[];
 }): string {
   let selectColumns: Set<string>;
   if (select) {
@@ -696,6 +713,7 @@ export function getColumnsToSelect<T extends Entity, K extends string & keyof Om
     }
   }
 
+  const baseColumnPrefix = getBaseColumnPrefix(model, joins);
   let query = '';
   for (const [index, propertyName] of Array.from(selectColumns).entries()) {
     const column = model.columnsByPropertyName[propertyName];
@@ -708,9 +726,9 @@ export function getColumnsToSelect<T extends Entity, K extends string & keyof Om
     }
 
     if (column.name === propertyName) {
-      query += `"${propertyName}"`;
+      query += `${baseColumnPrefix}"${propertyName}"`;
     } else {
-      query += `"${column.name}" AS "${propertyName}"`;
+      query += `${baseColumnPrefix}"${column.name}" AS "${propertyName}"`;
     }
   }
 
@@ -847,7 +865,7 @@ function buildSubqueryJoinClause<T extends Entity>({
     }
 
     assertValidSqlIdentifier(subqueryColumn, 'subquery join ON column');
-    onConditions.push(`"${model.tableName}"."${column.name}"="${join.alias}"."${subqueryColumn}"`);
+    onConditions.push(`${model.qualifiedTableName}."${column.name}"="${join.alias}"."${subqueryColumn}"`);
   }
 
   return ` ${joinType} (${subquerySQL}) AS "${join.alias}" ON ${onConditions.join(' AND ')}`;
@@ -1125,7 +1143,7 @@ export function buildOrderStatement<T extends Entity>({
         throw new QueryError(`Property (${propertyName}) not found in model (${model.name}).`, model);
       }
 
-      orderStatement += `"${column.name}"`;
+      orderStatement += `${getBaseColumnPrefix(model, joins)}"${column.name}"`;
     }
 
     if (descending) {
@@ -1347,7 +1365,7 @@ function buildWhere<T extends Entity>({
           repositoriesByModelNameLowered,
         });
 
-        return `"${column.name}"${isNegated ? ' NOT' : ''} IN (${subquerySQL})`;
+        return `${getBaseColumnPrefix(model, joins)}"${column.name}"${isNegated ? ' NOT' : ''} IN (${subquerySQL})`;
       }
 
       throw new QueryError(`Expected subquery value for 'in' operator. Property (${propertyName ?? ''}) in model (${model.name}).`, model);
@@ -1440,7 +1458,7 @@ function buildWhere<T extends Entity>({
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             const arrayColumnType = arrayColumn.type ? arrayColumn.type.toLowerCase() : '';
             if (arrayColumnType === 'array' || arrayColumnType === 'string[]' || arrayColumnType === 'integer[]' || arrayColumnType === 'float[]' || arrayColumnType === 'boolean[]') {
-              return `"${arrayColumn.name}"${isNegated ? '<>' : '='}'{}'`;
+              return `${getBaseColumnPrefix(model, joins)}"${arrayColumn.name}"${isNegated ? '<>' : '='}'{}'`;
             }
           }
 
@@ -1565,7 +1583,7 @@ function buildWhere<T extends Entity>({
               }
 
               params.push(valueWithoutNull);
-              orConstraints.push(`"${columnType.name}"${isNegated ? '<>ALL' : '=ANY'}($${params.length}${castType})`);
+              orConstraints.push(`${getBaseColumnPrefix(model, joins)}"${columnType.name}"${isNegated ? '<>ALL' : '=ANY'}($${params.length}${castType})`);
             }
           }
 
@@ -1640,6 +1658,7 @@ function buildWhere<T extends Entity>({
               if (parentColumn?.type?.toLowerCase() === 'json') {
                 andValues.push(
                   buildJsonPropertyClause({
+                    tablePrefix: getBaseColumnPrefix(model, joins),
                     columnName: parentColumn.name,
                     path: [key],
                     isNegated,
@@ -1945,7 +1964,7 @@ function buildArrayOrSingleStatement<T extends Entity>({
     }
 
     column = localColumn;
-    tablePrefix = '';
+    tablePrefix = getBaseColumnPrefix(model, joins);
   }
 
   if (value === null) {
@@ -2165,8 +2184,8 @@ function getTypeCastSuffix(value: unknown): string {
   return '';
 }
 
-function buildJsonAccessor(columnName: string, path: readonly string[]): string {
-  let result = `"${columnName}"`;
+function buildJsonAccessor(tablePrefix: string, columnName: string, path: readonly string[]): string {
+  let result = `${tablePrefix}"${columnName}"`;
   for (let i = 0; i < path.length; i++) {
     const arrow = i === path.length - 1 ? '->>' : '->';
     result += `${arrow}'${path[i]}'`;
@@ -2180,12 +2199,14 @@ function isJsonConstraintOperator(key: string): boolean {
 }
 
 function buildJsonPropertyClause({
+  tablePrefix,
   columnName,
   path,
   isNegated,
   constraint,
   params,
 }: {
+  tablePrefix: string;
   columnName: string;
   path: readonly string[];
   isNegated: boolean;
@@ -2197,11 +2218,11 @@ function buildJsonPropertyClause({
   }
 
   if (constraint === null) {
-    return `${buildJsonAccessor(columnName, path)} ${isNegated ? 'IS NOT' : 'IS'} NULL`;
+    return `${buildJsonAccessor(tablePrefix, columnName, path)} ${isNegated ? 'IS NOT' : 'IS'} NULL`;
   }
 
   if (Array.isArray(constraint)) {
-    const accessor = buildJsonAccessor(columnName, path);
+    const accessor = buildJsonAccessor(tablePrefix, columnName, path);
     params.push(constraint);
     return `${accessor}${isNegated ? '<>ALL' : '=ANY'}($${params.length})`;
   }
@@ -2212,7 +2233,7 @@ function buildJsonPropertyClause({
 
     // If first key is an operator, treat entire object as constraint operators
     if (firstKey && isJsonConstraintOperator(firstKey)) {
-      const accessor = buildJsonAccessor(columnName, path);
+      const accessor = buildJsonAccessor(tablePrefix, columnName, path);
       const negatedComparisonOperators: Record<string, string> = { '<': '>=', '<=': '>', '>': '<=', '>=': '<' };
       const clauses: string[] = [];
 
@@ -2243,6 +2264,7 @@ function buildJsonPropertyClause({
     for (const [nestedKey, nestedValue] of entries) {
       clauses.push(
         buildJsonPropertyClause({
+          tablePrefix,
           columnName,
           path: [...path, nestedKey],
           isNegated,
@@ -2256,7 +2278,7 @@ function buildJsonPropertyClause({
   }
 
   // Primitive value (string, number, boolean)
-  const accessor = buildJsonAccessor(columnName, path);
+  const accessor = buildJsonAccessor(tablePrefix, columnName, path);
   params.push(constraint);
   const castSuffix = getTypeCastSuffix(constraint);
   const castAccessor = castSuffix ? `(${accessor})${castSuffix}` : accessor;
@@ -2330,7 +2352,7 @@ function buildComparisonOperatorStatement<T extends Entity>({
     }
 
     column = localColumn;
-    tablePrefix = '';
+    tablePrefix = getBaseColumnPrefix(model, joins);
   }
 
   if (value === null) {

--- a/tests/readonlyRepository.test.ts
+++ b/tests/readonlyRepository.test.ts
@@ -2301,7 +2301,7 @@ describe('ReadonlyRepository', () => {
 
         const [query, params] = mockedPool.query.mock.calls[0]!;
         expect(query).toBe(
-          'SELECT "id","name","sku","location","alias_names" AS "aliases","store_id" AS "store" FROM "products" INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id" WHERE "store"."name" ILIKE $1',
+          'SELECT "products"."id","products"."name","products"."sku","products"."location","products"."alias_names" AS "aliases","products"."store_id" AS "store" FROM "products" INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id" WHERE "store"."name" ILIKE $1',
         );
         assert(params);
         expect(params).toStrictEqual(['Acme']);
@@ -2325,7 +2325,7 @@ describe('ReadonlyRepository', () => {
 
         const [query, params] = mockedPool.query.mock.calls[0]!;
         expect(query).toBe(
-          'SELECT "id","name","sku","location","alias_names" AS "aliases","store_id" AS "store" FROM "products" LEFT JOIN "stores" AS "store" ON "products"."store_id"="store"."id" WHERE "store"."name" ILIKE $1',
+          'SELECT "products"."id","products"."name","products"."sku","products"."location","products"."alias_names" AS "aliases","products"."store_id" AS "store" FROM "products" LEFT JOIN "stores" AS "store" ON "products"."store_id"="store"."id" WHERE "store"."name" ILIKE $1',
         );
         assert(params);
         expect(params).toStrictEqual(['%mart%']);
@@ -2349,7 +2349,7 @@ describe('ReadonlyRepository', () => {
 
         const [query, params] = mockedPool.query.mock.calls[0]!;
         expect(query).toBe(
-          'SELECT "id","name","sku","location","alias_names" AS "aliases","store_id" AS "store" FROM "products" INNER JOIN "stores" AS "primaryStore" ON "products"."store_id"="primaryStore"."id" WHERE "primaryStore"."name"=$1',
+          'SELECT "products"."id","products"."name","products"."sku","products"."location","products"."alias_names" AS "aliases","products"."store_id" AS "store" FROM "products" INNER JOIN "stores" AS "primaryStore" ON "products"."store_id"="primaryStore"."id" WHERE "primaryStore"."name"=$1',
         );
         assert(params);
         expect(params).toStrictEqual(['Acme']);
@@ -2374,7 +2374,7 @@ describe('ReadonlyRepository', () => {
 
         const [query, params] = mockedPool.query.mock.calls[0]!;
         expect(query).toBe(
-          'SELECT "id","name","sku","location","alias_names" AS "aliases","store_id" AS "store" FROM "products" INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id" WHERE "name"=$1 AND "store"."name"=$2',
+          'SELECT "products"."id","products"."name","products"."sku","products"."location","products"."alias_names" AS "aliases","products"."store_id" AS "store" FROM "products" INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id" WHERE "products"."name"=$1 AND "store"."name"=$2',
         );
         assert(params);
         expect(params).toStrictEqual(['Widget', 'Acme']);
@@ -2394,7 +2394,7 @@ describe('ReadonlyRepository', () => {
 
         const [query, params] = mockedPool.query.mock.calls[0]!;
         expect(query).toBe(
-          'SELECT "id","name","sku","location","alias_names" AS "aliases","store_id" AS "store" FROM "products" INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id" ORDER BY "store"."name"',
+          'SELECT "products"."id","products"."name","products"."sku","products"."location","products"."alias_names" AS "aliases","products"."store_id" AS "store" FROM "products" INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id" ORDER BY "store"."name"',
         );
         assert(params);
         expect(params).toStrictEqual([]);
@@ -2414,7 +2414,7 @@ describe('ReadonlyRepository', () => {
 
         const [query, params] = mockedPool.query.mock.calls[0]!;
         expect(query).toBe(
-          'SELECT "id","name","sku","location","alias_names" AS "aliases","store_id" AS "store" FROM "products" INNER JOIN "stores" AS "primaryStore" ON "products"."store_id"="primaryStore"."id" ORDER BY "primaryStore"."name" DESC',
+          'SELECT "products"."id","products"."name","products"."sku","products"."location","products"."alias_names" AS "aliases","products"."store_id" AS "store" FROM "products" INNER JOIN "stores" AS "primaryStore" ON "products"."store_id"="primaryStore"."id" ORDER BY "primaryStore"."name" DESC',
         );
         assert(params);
         expect(params).toStrictEqual([]);
@@ -2597,7 +2597,7 @@ describe('ReadonlyRepository', () => {
 
           const [query, params] = mockedPool.query.mock.calls[0]!;
           expect(query).toBe(
-            'SELECT "id","name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store"',
+            'SELECT "stores"."id","stores"."name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store"',
           );
           assert(params);
           expect(params).toStrictEqual([]);
@@ -2619,7 +2619,7 @@ describe('ReadonlyRepository', () => {
 
           const [query, params] = mockedPool.query.mock.calls[0]!;
           expect(query).toBe(
-            'SELECT "id","name" FROM "stores" LEFT JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store"',
+            'SELECT "stores"."id","stores"."name" FROM "stores" LEFT JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store"',
           );
           assert(params);
           expect(params).toStrictEqual([]);
@@ -2644,7 +2644,7 @@ describe('ReadonlyRepository', () => {
 
           const [query, params] = mockedPool.query.mock.calls[0]!;
           expect(query).toBe(
-            'SELECT "id","name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store" ORDER BY "productStats"."productCount" DESC',
+            'SELECT "stores"."id","stores"."name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store" ORDER BY "productStats"."productCount" DESC',
           );
           assert(params);
           expect(params).toStrictEqual([]);
@@ -2667,7 +2667,7 @@ describe('ReadonlyRepository', () => {
 
           const [query, params] = mockedPool.query.mock.calls[0]!;
           expect(query).toBe(
-            'SELECT "id","name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "widgetCount" FROM "products" WHERE "name"=$1 GROUP BY "store_id") AS "widgetStats" ON "stores"."id"="widgetStats"."store"',
+            'SELECT "stores"."id","stores"."name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "widgetCount" FROM "products" WHERE "name"=$1 GROUP BY "store_id") AS "widgetStats" ON "stores"."id"="widgetStats"."store"',
           );
           assert(params);
           expect(params).toStrictEqual(['Widget']);
@@ -2689,7 +2689,7 @@ describe('ReadonlyRepository', () => {
 
           const [query, params] = mockedPool.query.mock.calls[0]!;
           expect(query).toBe(
-            'SELECT "id","name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(DISTINCT "name") AS "uniqueNames" FROM "products" GROUP BY "store_id") AS "stats" ON "stores"."id"="stats"."store"',
+            'SELECT "stores"."id","stores"."name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(DISTINCT "name") AS "uniqueNames" FROM "products" GROUP BY "store_id") AS "stats" ON "stores"."id"="stats"."store"',
           );
           assert(params);
           expect(params).toStrictEqual([]);
@@ -2712,7 +2712,7 @@ describe('ReadonlyRepository', () => {
 
           const [query, params] = mockedPool.query.mock.calls[0]!;
           expect(query).toBe(
-            'SELECT "id","name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id" HAVING COUNT(*)>5) AS "productStats" ON "stores"."id"="productStats"."store"',
+            'SELECT "stores"."id","stores"."name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id" HAVING COUNT(*)>5) AS "productStats" ON "stores"."id"="productStats"."store"',
           );
           assert(params);
           expect(params).toStrictEqual([]);
@@ -2736,7 +2736,7 @@ describe('ReadonlyRepository', () => {
 
           const [query, params] = mockedPool.query.mock.calls[0]!;
           expect(query).toBe(
-            'SELECT "id","name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" WHERE "name" IS NOT NULL GROUP BY "store_id" HAVING COUNT(*)>=3) AS "productStats" ON "stores"."id"="productStats"."store"',
+            'SELECT "stores"."id","stores"."name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" WHERE "name" IS NOT NULL GROUP BY "store_id" HAVING COUNT(*)>=3) AS "productStats" ON "stores"."id"="productStats"."store"',
           );
           assert(params);
           expect(params).toStrictEqual([]);
@@ -2779,7 +2779,7 @@ describe('ReadonlyRepository', () => {
 
             const [query, params] = mockedPool.query.mock.calls[0]!;
             expect(query).toBe(
-              'SELECT "id","name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store" ORDER BY "productStats"."productCount" DESC',
+              'SELECT "stores"."id","stores"."name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store" ORDER BY "productStats"."productCount" DESC',
             );
             assert(params);
             expect(params).toStrictEqual([]);
@@ -2803,7 +2803,7 @@ describe('ReadonlyRepository', () => {
 
             const [query, params] = mockedPool.query.mock.calls[0]!;
             expect(query).toBe(
-              'SELECT "id","name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store" ORDER BY "productStats"."store"',
+              'SELECT "stores"."id","stores"."name" FROM "stores" INNER JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store" ORDER BY "productStats"."store"',
             );
             assert(params);
             expect(params).toStrictEqual([]);
@@ -2887,7 +2887,7 @@ describe('ReadonlyRepository', () => {
 
             const [query, params] = mockedPool.query.mock.calls[0]!;
             expect(query).toBe(
-              'SELECT "id","name" FROM "stores" LEFT JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store" ORDER BY "productStats"."productCount" DESC',
+              'SELECT "stores"."id","stores"."name" FROM "stores" LEFT JOIN (SELECT "store_id" AS "store",COUNT(*) AS "productCount" FROM "products" GROUP BY "store_id") AS "productStats" ON "stores"."id"="productStats"."store" ORDER BY "productStats"."productCount" DESC',
             );
             assert(params);
             expect(params).toStrictEqual([]);
@@ -2909,7 +2909,7 @@ describe('ReadonlyRepository', () => {
 
             const [query, params] = mockedPool.query.mock.calls[0]!;
             expect(query).toBe(
-              'SELECT "id","name" FROM "stores" INNER JOIN (SELECT DISTINCT ON ("store_id") "store_id" AS "store","name" FROM "products" ORDER BY "store_id") AS "latestProduct" ON "stores"."id"="latestProduct"."store"',
+              'SELECT "stores"."id","stores"."name" FROM "stores" INNER JOIN (SELECT DISTINCT ON ("store_id") "store_id" AS "store","name" FROM "products" ORDER BY "store_id") AS "latestProduct" ON "stores"."id"="latestProduct"."store"',
             );
             assert(params);
             expect(params).toStrictEqual([]);
@@ -2933,7 +2933,7 @@ describe('ReadonlyRepository', () => {
 
             const [query, params] = mockedPool.query.mock.calls[0]!;
             expect(query).toBe(
-              'SELECT "id","name" FROM "stores" LEFT JOIN (SELECT DISTINCT ON ("store_id") "store_id" AS "store","name" FROM "products" WHERE "name" IS NOT NULL ORDER BY "store_id") AS "latestProduct" ON "stores"."id"="latestProduct"."store"',
+              'SELECT "stores"."id","stores"."name" FROM "stores" LEFT JOIN (SELECT DISTINCT ON ("store_id") "store_id" AS "store","name" FROM "products" WHERE "name" IS NOT NULL ORDER BY "store_id") AS "latestProduct" ON "stores"."id"="latestProduct"."store"',
             );
             assert(params);
             expect(params).toStrictEqual([]);
@@ -2957,7 +2957,7 @@ describe('ReadonlyRepository', () => {
 
             const [query, params] = mockedPool.query.mock.calls[0]!;
             expect(query).toBe(
-              'SELECT "id","name" FROM "stores" INNER JOIN (SELECT DISTINCT ON ("store_id") "store_id" AS "store","name" FROM "products" ORDER BY "store_id","name" DESC) AS "latestProduct" ON "stores"."id"="latestProduct"."store"',
+              'SELECT "stores"."id","stores"."name" FROM "stores" INNER JOIN (SELECT DISTINCT ON ("store_id") "store_id" AS "store","name" FROM "products" ORDER BY "store_id","name" DESC) AS "latestProduct" ON "stores"."id"="latestProduct"."store"',
             );
             assert(params);
             expect(params).toStrictEqual([]);
@@ -3993,7 +3993,7 @@ describe('ReadonlyRepository', () => {
 
         const [query] = mockedPool.query.mock.calls[0]!;
         expect(query).toBe(
-          'SELECT "id","name","sku","location","alias_names" AS "aliases","store_id" AS "store",count(*) OVER() AS "__total_count__" FROM "products" INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id" WHERE "store"."name"=$1',
+          'SELECT "products"."id","products"."name","products"."sku","products"."location","products"."alias_names" AS "aliases","products"."store_id" AS "store",count(*) OVER() AS "__total_count__" FROM "products" INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id" WHERE "store"."name"=$1',
         );
       });
 

--- a/tests/sqlHelper.test.ts
+++ b/tests/sqlHelper.test.ts
@@ -34,6 +34,7 @@ import {
   SimpleWithCreatedAt,
   SimpleWithCreatedAtAndUpdatedAt,
   SimpleWithJson,
+  SimpleWithRelationAndJson,
   SimpleWithSchema,
   SimpleWithStringId,
   SimpleWithUpdatedAt,
@@ -57,6 +58,7 @@ interface RepositoriesByModelName {
   SimpleWithCreatedAt: IRepository<Entity>;
   SimpleWithCreatedAtAndUpdatedAt: IRepository<Entity>;
   SimpleWithJson: IRepository<Entity>;
+  SimpleWithRelationAndJson: IRepository<Entity>;
   SimpleWithSchema: IRepository<Entity>;
   SimpleWithStringId: IRepository<Entity>;
   SimpleWithUpdatedAt: IRepository<Entity>;
@@ -91,6 +93,7 @@ describe('sqlHelper', () => {
         SimpleWithCreatedAt,
         SimpleWithCreatedAtAndUpdatedAt,
         SimpleWithJson,
+        SimpleWithRelationAndJson,
         SimpleWithSchema,
         SimpleWithStringId,
         SimpleWithUpdatedAt,
@@ -394,6 +397,111 @@ describe('sqlHelper', () => {
 
         expect(query).toBe('SELECT DISTINCT ON ("store_id") "name","store_id" AS "store","id" FROM "products" ORDER BY "store_id"');
         expect(params).toStrictEqual([]);
+      });
+    });
+
+    describe('base-table column qualification with joins', () => {
+      it('should qualify base-table columns in SELECT, WHERE, and ORDER BY when a join is present', () => {
+        const { query, params } = sqlHelper.getSelectQueryAndParams<Product>({
+          repositoriesByModelNameLowered,
+          model: repositoriesByModelNameLowered.product.model as ModelMetadata<Product>,
+          select: ['id', 'name'],
+          where: { id: [1, 2], store: { name: 'Acme' } } as WhereQuery<Product>,
+          sorts: [{ propertyName: 'id' }],
+          skip: 0,
+          limit: 10,
+          joins: [{ propertyName: 'store', alias: 'store', type: 'inner' }],
+        });
+
+        expect(query).toBe(
+          'SELECT "products"."id","products"."name" FROM "products" INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id" WHERE "products"."id"=ANY($1::INTEGER[]) AND "store"."name"=$2 ORDER BY "products"."id" LIMIT 10',
+        );
+        expect(params).toStrictEqual([[1, 2], 'Acme']);
+      });
+
+      it('should qualify a base column used with an "in" subquery when a join is present', () => {
+        const storeSubquery = subquery(repositoriesByModelNameLowered.store as IRepository<Store>)
+          .select(['id'])
+          .where({ name: 'Acme' });
+
+        const { whereStatement, params } = sqlHelper.buildWhereStatement({
+          repositoriesByModelNameLowered,
+          model: repositoriesByModelNameLowered.product.model as ModelMetadata<Product>,
+          where: { id: { in: storeSubquery } } as WhereQuery<Product>,
+          joins: [{ propertyName: 'store', alias: 'store', type: 'inner' }],
+        });
+
+        expect(whereStatement).toBe('WHERE "products"."id" IN (SELECT "id" FROM "stores" WHERE "name"=$1)');
+        expect(params).toStrictEqual(['Acme']);
+      });
+
+      it('should qualify an array base column compared to an empty array when a join is present', () => {
+        const { whereStatement, params } = sqlHelper.buildWhereStatement({
+          repositoriesByModelNameLowered,
+          model: repositoriesByModelNameLowered.product.model as ModelMetadata<Product>,
+          where: { aliases: [] } as WhereQuery<Product>,
+          joins: [{ propertyName: 'store', alias: 'store', type: 'inner' }],
+        });
+
+        expect(whereStatement).toBe(`WHERE "products"."alias_names"='{}'`);
+        expect(params).toStrictEqual([]);
+      });
+
+      it('should qualify a base column in a multi-value =ANY constraint when a join is present', () => {
+        const { whereStatement, params } = sqlHelper.buildWhereStatement({
+          repositoriesByModelNameLowered,
+          model: repositoriesByModelNameLowered.product.model as ModelMetadata<Product>,
+          where: { name: ['Widget', 'Gadget'] } as WhereQuery<Product>,
+          joins: [{ propertyName: 'store', alias: 'store', type: 'inner' }],
+        });
+
+        expect(whereStatement).toBe('WHERE "products"."name"=ANY($1::TEXT[])');
+        expect(params).toStrictEqual([['Widget', 'Gadget']]);
+      });
+
+      it('should qualify a base JSON column property access when a join is present', () => {
+        const { whereStatement, params } = sqlHelper.buildWhereStatement({
+          repositoriesByModelNameLowered,
+          model: repositoriesByModelNameLowered.simplewithrelationandjson.model as ModelMetadata<SimpleWithRelationAndJson>,
+          where: { message: { id: 'abc' } } as WhereQuery<SimpleWithRelationAndJson>,
+          joins: [{ propertyName: 'store', alias: 'store', type: 'inner' }],
+        });
+
+        expect(whereStatement).toBe(`WHERE "simple"."message"->>'id'=$1`);
+        expect(params).toStrictEqual(['abc']);
+      });
+
+      it('should schema-qualify base columns and the subquery-join ON base side', () => {
+        const idSubquery = subquery(repositoriesByModelNameLowered.product as IRepository<Product>).select(['id']);
+
+        const { query, params } = sqlHelper.getSelectQueryAndParams<SimpleWithSchema>({
+          repositoriesByModelNameLowered,
+          model: repositoriesByModelNameLowered.simplewithschema.model as ModelMetadata<SimpleWithSchema>,
+          select: ['name'],
+          where: {},
+          sorts: [],
+          skip: 0,
+          limit: 0,
+          joins: [{ subquery: idSubquery, alias: 'stats', type: 'inner', on: { id: 'id' } }],
+        });
+
+        expect(query).toBe('SELECT "foo"."simple"."name","foo"."simple"."id" FROM "foo"."simple" INNER JOIN (SELECT "id" FROM "products") AS "stats" ON "foo"."simple"."id"="stats"."id"');
+        expect(params).toStrictEqual([]);
+      });
+
+      it('should not qualify base columns when there are no joins', () => {
+        const { query, params } = sqlHelper.getSelectQueryAndParams<Product>({
+          repositoriesByModelNameLowered,
+          model: repositoriesByModelNameLowered.product.model as ModelMetadata<Product>,
+          select: ['id', 'name'],
+          where: { id: [1, 2] } as WhereQuery<Product>,
+          sorts: [{ propertyName: 'id' }],
+          skip: 0,
+          limit: 10,
+        });
+
+        expect(query).toBe('SELECT "id","name" FROM "products" WHERE "id"=ANY($1::INTEGER[]) ORDER BY "id" LIMIT 10');
+        expect(params).toStrictEqual([[1, 2]]);
       });
     });
   });
@@ -3676,7 +3784,7 @@ describe('sqlHelper', () => {
         ],
       });
 
-      expect(result).toBe('ORDER BY "store"."name","name" DESC');
+      expect(result).toBe('ORDER BY "store"."name","products"."name" DESC');
     });
   });
 
@@ -3892,7 +4000,7 @@ describe('sqlHelper', () => {
         ],
       });
 
-      expect(whereStatement!).toBe('WHERE "name"=$1 AND "store"."name"=$2');
+      expect(whereStatement!).toBe('WHERE "products"."name"=$1 AND "store"."name"=$2');
       expect(params).toStrictEqual(['Widget', 'Acme']);
     });
 


### PR DESCRIPTION
## Problem

`.join()` lets a query filter by a joined table's columns, but base-table column references were emitted with no table prefix. When the base table and a joined table share a column name (most commonly `id`), Postgres rejects the query at runtime:

```text
error: column reference "id" is ambiguous
```

It type-checks fine and only fails on execution, so it was a silent footgun — consumers ended up avoiding `.join()` in favor of subqueries or raw SQL.

For example, `productRepository.find().join('store').where({ id: [1, 2], store: { name: 'Acme' } }).select(['id', 'name']).sort('id').limit(10)` previously generated:

```sql
SELECT "id","name" FROM "products"
INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id"
WHERE "id"=ANY($1::INTEGER[]) AND "store"."name"=$2 ORDER BY "id" LIMIT 10
```

`SELECT "id","name"`, `WHERE "id"`, and `ORDER BY "id"` are all ambiguous because `id`/`name` exist on both tables.

## Fix

Base-table columns are now qualified with the base table's name whenever a join is present, via a `getBaseColumnPrefix(model, joins)` helper applied across the SQL generation paths in `src/SqlHelper.ts`:

- SELECT list (`getColumnsToSelect`)
- `DISTINCT ON`
- `ORDER BY` (base-column fallback)
- WHERE leaf emitters (comparison, like, array, JSON containment, null)
- WHERE inline emitters (`in` subquery, empty array, multi-value `=ANY`/`<>ALL`)
- base-column JSON property access (threaded as a separate `tablePrefix` argument through `buildJsonPropertyClause`/`buildJsonAccessor`)

The same query now generates:

```sql
SELECT "products"."id","products"."name" FROM "products"
INNER JOIN "stores" AS "store" ON "products"."store_id"="store"."id"
WHERE "products"."id"=ANY($1::INTEGER[]) AND "store"."name"=$2 ORDER BY "products"."id" LIMIT 10
```

Subquery-join `ON` conditions now reference the base table via `model.qualifiedTableName` (previously `"${model.tableName}"`), so they are schema-qualified to match model joins.

Join-less queries are byte-for-byte unchanged (the prefix is empty when there are no joins), so existing non-join behavior does not churn.

## Tests

- New reproduction test asserting the qualified SELECT/WHERE/ORDER BY.
- Targeted assertions for each base-column emitter under a join: `in` subquery, empty-array, multi-value `=ANY`, base JSON property access, and a schema-qualified model (covering both base-column and subquery-join `ON` qualification).
- A regression guard asserting join-less queries stay unqualified.
- Updated the existing join/subquery-join expectations to the qualified form.

`npm run lint`, `npm run check:types`, and `npm test` (479 tests) all pass.

## Docs

Updated `docs/guide/subqueries-and-joins.md` so the `// SQL:` examples reflect the real emitted output, and added a note that base columns are auto-qualified under a join.
