### PR TITLE
chore: authenticate release with GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,19 @@ jobs:
     environment: production
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -53,4 +61,4 @@ jobs:
       - name: Release
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

The `Release` workflow's commit-back to `main` (changelog + version bump via `@semantic-release/git`) fails with:

> remote: error: GH006: Protected branch update failed for refs/heads/main.
> remote: - 4 of 4 required status checks are expected.

It pushes as `github-actions[bot]`, which can't satisfy `main`'s required status checks on a fresh direct push. This surfaced after `main`'s branch protection was tightened — the first release-triggering commit since then (#435's `fix:`) is the first to hit it. npm publish + the GitHub Release happen via the API and were never affected; only the git commit-back is blocked.

## Fix

- Mint a short-lived **GitHub App** installation token via `actions/create-github-app-token` (pinned to SHA) and use it for checkout and `semantic-release`, replacing the default `GITHUB_TOKEN`.
- `main` migrates from **classic branch protection** to a **repository ruleset** that mirrors the previous rules (same 4 required checks with `strict=false`, block force-push, block deletion) and lists the release App as a **bypass actor** — the only mechanism that lets an App through required checks (classic protection has no per-App bypass).

## Setup (completed)

- Repo secrets `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY`.
- Ruleset on `main` with the App as a bypass actor; classic protection removed (snapshot kept for rollback).

Merging this ships the pending **15.11.10** (the unreleased `fix:` from #435).

Refs bigal-3cu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
