### PR TITLE
chore(ci): drop Node.js 20 from the test matrix, add Node.js 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['20', '22', '24']
+        node-version: ['22', '24', '26']
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

Updates the CI test matrix from Node.js `20 / 22 / 24` to `22 / 24 / 26`.

Node.js 26 is the current release line (26.5.0 as of 2026-07-08) and is scheduled to enter Active LTS in October 2026.

## Notes

- `engines.node` in package.json still advertises `>=20.11.0`. Bumping it to `>=22` is a breaking change for consumers, so it is intentionally **not** part of this CI-only PR — #360 already plans that drop as part of its major. Until then, Node 20 remains claimed-but-untested.
- `docs.yml` (pinned to Node 24.18.0) and the `lts/*` jobs in `ci.yml`/`release.yml` are unchanged.