### PR TITLE
docs: recommend count() over findOne() for existence checks

### DIFF
--- a/docs/guide/crud-operations.md
+++ b/docs/guide/crud-operations.md
@@ -29,6 +29,20 @@ const products = await productRepository.create([
 // products = [{ id: 42, ... }, { id: 43, ... }]
 ```
 
+Passing an array builds a single multi-row `INSERT` statement, one round trip for the whole batch. Prefer this over calling
+`create()` in a loop, which issues a separate `INSERT` (and round trip) per record:
+
+```ts
+// Correct — one INSERT statement for all rows
+const products = await productRepository.create(items);
+
+// Slower — a separate INSERT statement and round trip per item
+const products = [];
+for (const item of items) {
+  products.push(await productRepository.create(item));
+}
+```
+
 ### Skip returning records
 
 ```ts

--- a/docs/guide/querying.md
+++ b/docs/guide/querying.md
@@ -57,6 +57,12 @@ const count = await productRepository.count().where({
 });
 ```
 
+If you only need to know whether a match exists, use `count()` instead of `findOne()` — it performs better since it doesn't select or hydrate a row:
+
+```ts
+const exists = (await productRepository.count().where({ sku: 'ABC123' })) > 0;
+```
+
 ## Where operators
 
 ### String matching

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -71,6 +71,8 @@ repository.create(values[], options?): Promise<QueryResult<T>[]>
 
 Insert one or multiple records. Options: `{ returnRecords?, returnSelect?, onConflict? }`.
 
+An array inserts in a single statement. Prefer this over calling `create()` in a loop, which costs one round trip per record.
+
 ### update()
 
 ```ts

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -60,7 +60,7 @@ Returns a query builder for a single record or `null`. Options: `{ select?, pool
 repository.count(options?): CountQuery<T>
 ```
 
-Returns a query builder that resolves to a number. Options: `{ pool? }`.
+Returns a query builder that resolves to a number. Options: `{ pool? }`. Prefer this over `findOne()` for existence checks — it performs better since it doesn't select or hydrate a row.
 
 ### create()
 

--- a/skills/using-bigal/SKILL.md
+++ b/skills/using-bigal/SKILL.md
@@ -463,6 +463,21 @@ const exists = (await productRepo.count().where({ sku: 'ABC123' })) > 0;
 const exists = (await productRepo.findOne().where({ sku: 'ABC123' })) != null;
 ```
 
+### Prefer an array to create() over looping
+
+Passing an array to `create()` builds a single multi-row `INSERT` statement — one round trip for the whole batch. Calling `create()` in a loop issues a separate `INSERT` (and round trip) per record:
+
+```ts
+// Correct — one INSERT statement for all rows
+const products = await productRepo.create(items);
+
+// Slower — a separate INSERT statement and round trip per item
+const products = [];
+for (const item of items) {
+  products.push(await productRepo.create(item));
+}
+```
+
 ### Debugging SQL
 
 Set `DEBUG_BIGAL=true` to log all generated SQL and parameter values:

--- a/skills/using-bigal/SKILL.md
+++ b/skills/using-bigal/SKILL.md
@@ -451,6 +451,18 @@ type ProductSummary = Pick<QueryResult<Product>, 'id' | 'name' | 'store'>;
 type ProductSummaryWrong = Pick<Product, 'id' | 'name' | 'store'>;
 ```
 
+### Prefer count() over findOne() for existence checks
+
+If you only need to know whether a match exists, use `count()` instead of `findOne()` — it performs better since it doesn't select or hydrate a row:
+
+```ts
+// Correct
+const exists = (await productRepo.count().where({ sku: 'ABC123' })) > 0;
+
+// Wasteful — findOne() selects and hydrates a full row just to check for existence
+const exists = (await productRepo.findOne().where({ sku: 'ABC123' })) != null;
+```
+
 ### Debugging SQL
 
 Set `DEBUG_BIGAL=true` to log all generated SQL and parameter values:


### PR DESCRIPTION
## Summary

- Adds a tip to the SKILL.md gotchas section, the querying guide, and the API reference: use `count()` instead of `findOne()` when only checking whether a match exists, since `count()` doesn't select or hydrate a row.

## Test plan

- [x] `pnpm run lint` (markdownlint + vp fmt/lint) passes clean