### PR TITLE
docs: clarify data-shaping and populate/join behavior, fix destroy return defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Known Vulnerabilities](https://snyk.io/test/npm/bigal/badge.svg)](https://snyk.io/test/npm/bigal)
 
 A PostgreSQL-optimized, type-safe TypeScript ORM for Node.js. BigAl uses a fluent builder pattern for queries,
-decorator-based models, and immutable query state. Built exclusively for Postgres — queries are tuned for
+decorator-based models, and immutable query state. Built exclusively for Postgres - queries are tuned for
 Postgres performance with native support for JSONB, DISTINCT ON, subquery joins, ON CONFLICT upserts, and pgvector.
 
 ## Install
@@ -49,7 +49,7 @@ const pool = new Pool('postgres://localhost/mydb');
 const repos = initialize({ models: [Product], pool });
 const productRepository = repos.Product as Repository<Product>;
 
-// Fluent queries — just await the chain
+// Fluent queries - just await the chain
 const products = await productRepository
   .find()
   .where({ priceCents: { '>=': 1000 }, name: { contains: 'widget' } })
@@ -64,12 +64,12 @@ await productRepository.create({ name: 'Widget', sku: 'WDG-001', priceCents: 999
 
 Full documentation is available at **[bigalorm.github.io/bigal](https://bigalorm.github.io/bigal/)**.
 
-- [Getting Started](https://bigalorm.github.io/bigal/getting-started) — install, first model, first query
-- [Models](https://bigalorm.github.io/bigal/guide/models) — decorators, column options, relationships
-- [Querying](https://bigalorm.github.io/bigal/guide/querying) — operators, pagination, JSONB, DISTINCT ON
-- [CRUD Operations](https://bigalorm.github.io/bigal/guide/crud-operations) — create, update, destroy, upserts
-- [Subqueries & Joins](https://bigalorm.github.io/bigal/guide/subqueries-and-joins) — subquery builder, aggregates
-- [API Reference](https://bigalorm.github.io/bigal/reference/api) — all exports and method signatures
+- [Getting Started](https://bigalorm.github.io/bigal/getting-started) - install, first model, first query
+- [Models](https://bigalorm.github.io/bigal/guide/models) - decorators, column options, relationships
+- [Querying](https://bigalorm.github.io/bigal/guide/querying) - operators, pagination, JSONB, DISTINCT ON
+- [CRUD Operations](https://bigalorm.github.io/bigal/guide/crud-operations) - create, update, destroy, upserts
+- [Subqueries & Joins](https://bigalorm.github.io/bigal/guide/subqueries-and-joins) - subquery builder, aggregates
+- [API Reference](https://bigalorm.github.io/bigal/reference/api) - all exports and method signatures
 
 ## Machine-Readable Documentation
 

--- a/docs/advanced/known-issues.md
+++ b/docs/advanced/known-issues.md
@@ -1,5 +1,5 @@
 ---
-description: Known issues and workarounds — optional collections, NotEntity for JSON objects with id fields, and DEBUG_BIGAL logging.
+description: Known issues and workarounds - optional collections, NotEntity for JSON objects with id fields, and DEBUG_BIGAL logging.
 ---
 
 # Known Issues
@@ -13,7 +13,7 @@ Collection properties (one-to-many, many-to-many) must be declared as optional. 
 @column({ collection: () => 'Product', via: 'store' })
 public products?: Product[];
 
-// Incorrect — causes type issues
+// Incorrect - causes type issues
 @column({ collection: () => 'Product', via: 'store' })
 public products!: Product[];
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,7 +67,7 @@ const productRepository = repos.Product as Repository<Product>;
 
 ## Run your first query
 
-Queries use a fluent builder and are `PromiseLike` — just `await` the chain.
+Queries use a fluent builder and are `PromiseLike` - just `await` the chain.
 
 ```ts
 // Find all products with price >= 1000 cents, sorted by name
@@ -95,12 +95,12 @@ npx skills add bigalorm/bigal
 
 Machine-readable documentation is also available:
 
-- [llms.txt](/llms.txt) — structured overview
-- [llms-full.txt](/llms-full.txt) — complete documentation in a single file
+- [llms.txt](/llms.txt) - structured overview
+- [llms-full.txt](/llms-full.txt) - complete documentation in a single file
 
 ## Next steps
 
-- [Models](/guide/models) — decorators, relationships, and Entity types
-- [Querying](/guide/querying) — operators, pagination, JSONB, and more
-- [CRUD Operations](/guide/crud-operations) — create, update, and destroy
-- [API Reference](/reference/api) — all exports and method signatures
+- [Models](/guide/models) - decorators, relationships, and Entity types
+- [Querying](/guide/querying) - operators, pagination, JSONB, and more
+- [CRUD Operations](/guide/crud-operations) - create, update, and destroy
+- [API Reference](/reference/api) - all exports and method signatures

--- a/docs/guide/crud-operations.md
+++ b/docs/guide/crud-operations.md
@@ -35,10 +35,10 @@ Passing an array builds a single multi-row `INSERT` statement, one round trip fo
 `create()` in a loop, which issues a separate `INSERT` (and round trip) per record:
 
 ```ts
-// Correct — one INSERT statement for all rows
+// Correct - one INSERT statement for all rows
 const products = await productRepository.create(items);
 
-// Slower — a separate INSERT statement and round trip per item
+// Slower - a separate INSERT statement and round trip per item
 const products = [];
 for (const item of items) {
   products.push(await productRepository.create(item));

--- a/docs/guide/crud-operations.md
+++ b/docs/guide/crud-operations.md
@@ -4,8 +4,10 @@ description: Create, update, and destroy records with RETURNING support, query p
 
 # CRUD Operations
 
-BigAl repositories provide `create()`, `update()`, and `destroy()` methods. All three return affected records
-by default (using `RETURNING *`), and all support `returnRecords` and `returnSelect` options.
+BigAl repositories provide `create()`, `update()`, and `destroy()` methods.
+`create()` and `update()` return affected records by default (using `RETURNING *`); `destroy()` does not.
+All three accept `returnRecords` and `returnSelect` to shape what comes back.
+Return only the columns you need, or skip the returned rows entirely, to reduce bytes over the wire and hydration cost.
 
 ## Create
 
@@ -143,26 +145,25 @@ const products = await productRepository.update({ id: [42, 43] }, { priceCents: 
 
 ## Destroy
 
-`destroy()` takes a where clause object. Returns an array of deleted records.
+`destroy()` takes a where clause object. Unlike `create()` and `update()`, it does not return records by default.
+It emits a plain `DELETE` with no `RETURNING` clause and resolves to `void`, which is the cheapest option.
 
 ```ts
-// Delete a single record
-const products = await productRepository.destroy({ id: 42 });
-// products = [{ id: 42, name: 'Super Widget', ... }]
+// Delete a single record (resolves to void)
+await productRepository.destroy({ id: 42 });
 
 // Delete multiple records
-const products = await productRepository.destroy({ id: [42, 43] });
+await productRepository.destroy({ id: [42, 43] });
 ```
 
-> `destroy()` always returns an array, regardless of how many records were affected.
-
-Without returning records:
+To get the deleted rows back, opt in with `returnRecords: true`:
 
 ```ts
-await productRepository.destroy({ id: 42 }, { returnRecords: false });
+const products = await productRepository.destroy({ id: [42, 43] }, { returnRecords: true });
+// products = [{ id: 42, ... }, { id: 43, ... }]
 ```
 
-With query projection:
+With query projection (implies `returnRecords`):
 
 ```ts
 const products = await productRepository.destroy({ id: [42, 43] }, { returnSelect: ['name'] });

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -67,7 +67,7 @@ public embedding?: number[];
 ```
 
 Requires the [pgvector](https://github.com/pgvector/pgvector) extension. The `dimensions` option is
-informational — BigAl does not issue DDL. See
+informational - BigAl does not issue DDL. See
 [Querying > Vector distance queries](/guide/querying#vector-distance-queries) for sorting and
 filtering by similarity.
 
@@ -112,7 +112,7 @@ public version!: number;
 | `name`       | `string`       | Database column name (if different from property name)                                                                                                              |
 | `required`   | `boolean`      | If `true`, value must not be null                                                                                                                                   |
 | `defaultsTo` | `any`          | Default value                                                                                                                                                       |
-| `dimensions` | `number`       | Number of dimensions for `'vector'` columns. Informational only — BigAl does not issue DDL                                                                          |
+| `dimensions` | `number`       | Number of dimensions for `'vector'` columns. Informational only - BigAl does not issue DDL                                                                          |
 | `model`      | `() => string` | Foreign key relationship (many-to-one)                                                                                                                              |
 | `collection` | `() => string` | Inverse relationship (one-to-many or many-to-many)                                                                                                                  |
 | `through`    | `() => string` | Join table for many-to-many                                                                                                                                         |
@@ -138,7 +138,7 @@ export class Product extends Entity {
 }
 ```
 
-The property type is `number | Store` — it holds the foreign key when not populated, or the full entity after `.populate()`.
+The property type is `number | Store` - it holds the foreign key when not populated, or the full entity after `.populate()`.
 
 ### One-to-many
 
@@ -168,7 +168,7 @@ See [Relationships](/guide/relationships) for complete examples including join t
 
 ## Entity base class
 
-All models extend `Entity`, which provides no properties by itself — it serves as a marker for BigAl's type system to distinguish ORM entities from plain objects.
+All models extend `Entity`, which provides no properties by itself - it serves as a marker for BigAl's type system to distinguish ORM entities from plain objects.
 
 ## NotEntity\<T\>
 

--- a/docs/guide/querying.md
+++ b/docs/guide/querying.md
@@ -17,7 +17,10 @@ const product = await productRepository.findOne().where({ id: 42 });
 
 ### Query projection
 
-Select specific columns:
+Pass `select` to return only the columns you need instead of every column (the default).
+This shrinks the SELECT list, reduces bytes transferred, and lowers hydration cost.
+It is a large win for wide rows, big JSON blobs, or vector/embedding columns you do not need on a given path.
+`find()` and `populate()` accept the same option.
 
 ```ts
 const product = await productRepository
@@ -25,6 +28,9 @@ const product = await productRepository
     select: ['name', 'sku'],
   })
   .where({ id: 42 });
+
+// find() takes the same option
+const products = await productRepository.find({ select: ['name', 'sku'] }).where({ store: storeId });
 ```
 
 ### Pool override

--- a/docs/guide/querying.md
+++ b/docs/guide/querying.md
@@ -340,6 +340,13 @@ const product = await productRepository
 console.log(product.store.name);
 ```
 
+`populate()` does not use a SQL `JOIN`.
+After the main query resolves, it runs a separate query per populated relation (batched by id and hydrated back onto the results), so `.join()` is not required to populate a relation.
+Every matched primary row is returned whether or not the relation exists - an absent to-one is `undefined`, an empty to-many is `[]`.
+The populate `where`/`limit` options constrain only the related rows, never the primary results.
+Reach for [`.join()`](/guide/subqueries-and-joins#model-joins) only to constrain or sort the primary results by columns on the related table (for example, only products whose store is active).
+Without such a constraint, `.populate()` on its own is all you need.
+
 ## toJSON
 
 Return plain objects without class prototypes:

--- a/docs/guide/querying.md
+++ b/docs/guide/querying.md
@@ -4,7 +4,7 @@ description: Fluent query builder for find, findOne, and count with WHERE operat
 
 # Querying
 
-BigAl provides `findOne()`, `find()`, and `count()` methods on repositories. Queries use a fluent builder pattern —
+BigAl provides `findOne()`, `find()`, and `count()` methods on repositories. Queries use a fluent builder pattern -
 each method returns a new immutable instance, and queries are `PromiseLike` so you can `await` them directly.
 
 ## findOne
@@ -63,7 +63,7 @@ const count = await productRepository.count().where({
 });
 ```
 
-If you only need to know whether a match exists, use `count()` instead of `findOne()` — it performs better since it doesn't select or hydrate a row:
+If you only need to know whether a match exists, use `count()` instead of `findOne()` - it performs better since it doesn't select or hydrate a row:
 
 ```ts
 const exists = (await productRepository.count().where({ sku: 'ABC123' })) > 0;
@@ -193,9 +193,9 @@ await repo.find().where({ bar: { theme: { '!': null } } });
 ```
 
 Note that `IS NULL` on a JSONB property is true both when the key is missing from the object and when it is
-explicitly set to `null`. This matches PostgreSQL's behavior — the `->>` operator returns `NULL` in both cases.
+explicitly set to `null`. This matches PostgreSQL's behavior - the `->>` operator returns `NULL` in both cases.
 
-Properties set to `undefined` in a where clause are silently ignored (standard JavaScript — `undefined` values are
+Properties set to `undefined` in a where clause are silently ignored (standard JavaScript - `undefined` values are
 dropped by `Object.entries`). To query for missing or null properties, always use `null` explicitly.
 
 ### JSONB containment

--- a/docs/guide/relationships.md
+++ b/docs/guide/relationships.md
@@ -212,3 +212,4 @@ const compilation = await compilationRepository
 3. **Mark collections as optional** — they are `undefined` unless populated
 4. **Avoid type assertions** — `QueryResult` narrows types automatically
 5. **Use `.toJSON()` for serializable results** — strips class prototypes
+6. **Load relations with `.populate()`** - it runs a separate query per relation and does not require `.join()`; reach for `.join()` only to constrain the primary results by a related table

--- a/docs/guide/relationships.md
+++ b/docs/guide/relationships.md
@@ -27,7 +27,7 @@ export class Product extends Entity {
 }
 ```
 
-- The property type is `number | Store` — foreign key when not populated, full entity after `.populate()`
+- The property type is `number | Store` - foreign key when not populated, full entity after `.populate()`
 - Use `name: 'store_id'` when the database column differs from the property name
 - Reference the model by string name (`'Store'`) to avoid circular imports
 - Model names are case-insensitive
@@ -54,7 +54,7 @@ export class Store extends Entity {
 ```
 
 - `via` references the property name on the related model (not the database column)
-- Collections **must** be optional (`?`) — they are only present after `.populate()`
+- Collections **must** be optional (`?`) - they are only present after `.populate()`
 
 ## Many-to-many (through)
 
@@ -207,9 +207,9 @@ const compilation = await compilationRepository
 
 ## Best practices
 
-1. **Use `QueryResult<T>` for return types** — avoids union type ambiguity
-2. **Use string references for model names** — prevents circular imports
-3. **Mark collections as optional** — they are `undefined` unless populated
-4. **Avoid type assertions** — `QueryResult` narrows types automatically
-5. **Use `.toJSON()` for serializable results** — strips class prototypes
+1. **Use `QueryResult<T>` for return types** - avoids union type ambiguity
+2. **Use string references for model names** - prevents circular imports
+3. **Mark collections as optional** - they are `undefined` unless populated
+4. **Avoid type assertions** - `QueryResult` narrows types automatically
+5. **Use `.toJSON()` for serializable results** - strips class prototypes
 6. **Load relations with `.populate()`** - it runs a separate query per relation and does not require `.join()`; reach for `.join()` only to constrain the primary results by a related table

--- a/docs/guide/subqueries-and-joins.md
+++ b/docs/guide/subqueries-and-joins.md
@@ -119,6 +119,15 @@ const products = await productRepository.find().leftJoin('store', 'activeStore',
 When a query includes any join, BigAl automatically qualifies the base table's own columns (in `SELECT`, `WHERE`, `ORDER BY`, and `DISTINCT ON`) with the base table name.
 This keeps columns that share a name across the base and joined tables (most commonly `id`) from being ambiguous, so `.join()` is safe to use without falling back to raw SQL.
 
+### `.join()` vs `.populate()`
+
+`.join()` and [`.populate()`](/guide/querying#populate) solve different problems, and you do not need `.join()` to populate a relation:
+
+- `.join()` adds a SQL `JOIN` to the main query so you can filter or sort the base results by columns on the related table. It does not hydrate the related entity onto a nested property.
+- `.populate()` loads the related records. It runs a separate query after the main query resolves (not a `JOIN`) and nests the results, so it works on its own.
+
+Use `.join()` alongside `.populate()` only when you also need to constrain the base results by the related table. Without such a constraint, `.populate()` by itself is enough.
+
 ## Subquery joins
 
 Join to subquery results:

--- a/docs/guide/views.md
+++ b/docs/guide/views.md
@@ -5,7 +5,7 @@ description: Map PostgreSQL views to readonly models with ReadonlyRepository. Su
 # Views and Readonly Repositories
 
 BigAl does not distinguish between tables and views. Both use the `@table()` decorator. Setting `readonly: true` causes
-`initialize()` to return a `ReadonlyRepository` — which omits `create`, `update`, and `destroy` methods,
+`initialize()` to return a `ReadonlyRepository` - which omits `create`, `update`, and `destroy` methods,
 catching accidental writes at compile time.
 
 BigAl does not create or manage views. Create them in PostgreSQL via your migration tool.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ features:
   - title: Decorator-based models
     details: Define tables, columns, and relationships with TypeScript decorators. Inheritance and schema support built in.
   - title: Type-safe queries
-    details: WhereQuery types narrow automatically — relationship fields resolve to foreign keys or populated entities without type assertions.
+    details: WhereQuery types narrow automatically - relationship fields resolve to foreign keys or populated entities without type assertions.
 ---
 
 <!-- markdownlint-disable MD013 MD033 MD041 -->
@@ -48,7 +48,7 @@ features:
 <div class="code-showcase">
 
 <h2>What it looks like</h2>
-<p class="subtitle">Define a model, query it — that's it.</p>
+<p class="subtitle">Define a model, query it - that's it.</p>
 
 ```ts
 import { column, primaryColumn, table, Entity, initialize } from 'bigal';
@@ -75,7 +75,7 @@ const repos = initialize({
 });
 const productRepo = repos.Product as Repository<Product>;
 
-// Fluent queries — just await the chain
+// Fluent queries - just await the chain
 const products = await productRepo
   .find()
   .where({ priceCents: { '>': 1000 }, name: { contains: 'widget' } })

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,5 +1,5 @@
 ---
-description: Complete API reference for BigAl — initialize(), Repository, ReadonlyRepository, query builder methods, subquery(), decorators, and types.
+description: Complete API reference for BigAl - initialize(), Repository, ReadonlyRepository, query builder methods, subquery(), decorators, and types.
 ---
 
 # API Reference
@@ -60,7 +60,7 @@ Returns a query builder for a single record or `null`. Options: `{ select?, pool
 repository.count(options?): CountQuery<T>
 ```
 
-Returns a query builder that resolves to a number. Options: `{ pool? }`. Prefer this over `findOne()` for existence checks — it performs better since it doesn't select or hydrate a row.
+Returns a query builder that resolves to a number. Options: `{ pool? }`. Prefer this over `findOne()` for existence checks - it performs better since it doesn't select or hydrate a row.
 
 ### create()
 
@@ -147,7 +147,7 @@ Marks the primary key. Options: `{ type }`.
 ### @column(options)
 
 Defines a column. See [Models > Column options](/guide/models#column-options) for all options.
-Vector columns are declared with `{ type: 'vector', dimensions: n }` (`dimensions` is informational —
+Vector columns are declared with `{ type: 'vector', dimensions: n }` (`dimensions` is informational -
 BigAl does not issue DDL).
 
 ### @createDateColumn()

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -73,21 +73,25 @@ Insert one or multiple records. Options: `{ returnRecords?, returnSelect?, onCon
 
 An array inserts in a single statement. Prefer this over calling `create()` in a loop, which costs one round trip per record.
 
+`returnSelect` narrows the returned columns and `returnRecords: false` skips them entirely, cutting transfer and hydration cost.
+
 ### update()
 
 ```ts
 repository.update(where, values, options?): Promise<QueryResult<T>[]>
 ```
 
-Update matching records. Options: `{ returnRecords?, returnSelect? }`.
+Update matching records. Options: `{ returnRecords?, returnSelect? }`. As with `create()`, use `returnSelect` to return only the columns you need or `returnRecords: false` to skip the returned rows.
 
 ### destroy()
 
 ```ts
-repository.destroy(where, options?): Promise<QueryResult<T>[]>
+repository.destroy(where, options?): Promise<void>
+repository.destroy(where, { returnRecords: true }): Promise<QueryResult<T>[]>
 ```
 
 Delete matching records. Options: `{ returnRecords?, returnSelect? }`.
+Unlike `create()`/`update()`, `destroy()` does not return records by default (plain `DELETE`, no `RETURNING`); pass `returnRecords: true` or `returnSelect` to get the deleted rows back.
 
 ## ReadonlyRepository
 

--- a/skills/using-bigal/SKILL.md
+++ b/skills/using-bigal/SKILL.md
@@ -61,7 +61,7 @@ const products = await productRepository
 - Bulk operations with custom locking (SELECT FOR UPDATE)
 - Database-specific features BigAl does not wrap
 
-BigAl wraps your existing connection pool — `postgres-pool`, `pg`, or `@neondatabase/serverless`.
+BigAl wraps your existing connection pool - `postgres-pool`, `pg`, or `@neondatabase/serverless`.
 The pool is always accessible for raw queries, so you can eject to SQL at any point:
 
 ```ts
@@ -147,25 +147,25 @@ class Product extends Entity {
 `'string'`, `'integer'`, `'float'`, `'boolean'`, `'date'`, `'datetime'`, `'json'`, `'string[]'`, `'integer[]'`, `'float[]'`, `'boolean[]'`, `'vector'`
 
 Vector columns (pgvector) are declared with `@column({ type: 'vector', dimensions: n })` on a `number[]` property.
-`dimensions` is informational — BigAl does not issue DDL.
+`dimensions` is informational - BigAl does not issue DDL.
 
 ### Relationships
 
-**Many-to-one** — current entity holds the foreign key:
+**Many-to-one** - current entity holds the foreign key:
 
 ```ts
 @column({ model: () => 'Store', name: 'store_id' })
 public store!: number | Store;
 ```
 
-**One-to-many** — inverse side (must be optional):
+**One-to-many** - inverse side (must be optional):
 
 ```ts
 @column({ collection: () => 'Product', via: 'store' })
 public products?: Product[];
 ```
 
-**Many-to-many** — requires a join table Entity:
+**Many-to-many** - requires a join table Entity:
 
 ```ts
 @column({
@@ -193,7 +193,7 @@ class ProductSummary extends Entity {
 
 ### Fluent builder
 
-Every query method returns a new immutable instance. Queries are `PromiseLike` — just `await` the chain.
+Every query method returns a new immutable instance. Queries are `PromiseLike` - just `await` the chain.
 
 ```ts
 // Find multiple
@@ -320,7 +320,7 @@ ORDER BY must start with the DISTINCT ON columns. Cannot combine with `withCount
 ### Create
 
 ```ts
-// Single record — returns the created record
+// Single record - returns the created record
 const product = await productRepo.create({ name: 'Widget', priceCents: 999 });
 
 // Multiple records
@@ -401,7 +401,7 @@ await productRepo.find().where({ price: { '>': avgPrice } });
 ```ts
 // In the model: @column({ type: 'vector', dimensions: 1536 }) public embedding?: number[];
 
-// Sort by similarity — metric: 'cosine' (default, <=>), 'l2' (<->), 'l1' (<+>), 'innerProduct' (<#>)
+// Sort by similarity - metric: 'cosine' (default, <=>), 'l2' (<->), 'l1' (<+>), 'innerProduct' (<#>)
 const similar = await documentRepo
   .find()
   .sort({ embedding: { nearestTo: queryVector, metric: 'cosine' } })
@@ -429,7 +429,7 @@ Collection properties (one-to-many, many-to-many) must use `?`, not `!`. They ar
 @column({ collection: () => 'Product', via: 'store' })
 public products?: Product[];
 
-// Wrong — causes QueryResult type errors
+// Wrong - causes QueryResult type errors
 @column({ collection: () => 'Product', via: 'store' })
 public products!: Product[];
 ```
@@ -460,7 +460,7 @@ const query = productRepo.find().where({ store: storeId });
 const sorted = query.sort('name asc');
 const results = await sorted.limit(10);
 
-// Wrong — .sort() result is discarded
+// Wrong - .sort() result is discarded
 const query = productRepo.find().where({ store: storeId });
 query.sort('name asc'); // This does nothing to `query`
 const results = await query;
@@ -503,25 +503,25 @@ const products = await productRepo
 
 ### Prefer count() over findOne() for existence checks
 
-If you only need to know whether a match exists, use `count()` instead of `findOne()` — it performs better since it doesn't select or hydrate a row:
+If you only need to know whether a match exists, use `count()` instead of `findOne()` - it performs better since it doesn't select or hydrate a row:
 
 ```ts
 // Correct
 const exists = (await productRepo.count().where({ sku: 'ABC123' })) > 0;
 
-// Wasteful — findOne() selects and hydrates a full row just to check for existence
+// Wasteful - findOne() selects and hydrates a full row just to check for existence
 const exists = (await productRepo.findOne().where({ sku: 'ABC123' })) != null;
 ```
 
 ### Prefer an array to create() over looping
 
-Passing an array to `create()` builds a single multi-row `INSERT` statement — one round trip for the whole batch. Calling `create()` in a loop issues a separate `INSERT` (and round trip) per record:
+Passing an array to `create()` builds a single multi-row `INSERT` statement - one round trip for the whole batch. Calling `create()` in a loop issues a separate `INSERT` (and round trip) per record:
 
 ```ts
-// Correct — one INSERT statement for all rows
+// Correct - one INSERT statement for all rows
 const products = await productRepo.create(items);
 
-// Slower — a separate INSERT statement and round trip per item
+// Slower - a separate INSERT statement and round trip per item
 const products = [];
 for (const item of items) {
   products.push(await productRepo.create(item));
@@ -553,14 +553,14 @@ After applying this skill, verify:
 
 ## Further Reading
 
-- [Getting Started](https://bigalorm.github.io/bigal/getting-started) — install, first model, first query
-- [Models](https://bigalorm.github.io/bigal/guide/models) — decorators, column options, relationships
-- [Querying](https://bigalorm.github.io/bigal/guide/querying) — operators, pagination, JSONB, DISTINCT ON
-- [CRUD Operations](https://bigalorm.github.io/bigal/guide/crud-operations) — create, update, destroy, upserts
-- [Relationships](https://bigalorm.github.io/bigal/guide/relationships) — many-to-one, one-to-many, many-to-many, QueryResult
-- [Subqueries and Joins](https://bigalorm.github.io/bigal/guide/subqueries-and-joins) — subquery builder, aggregates, GROUP BY
-- [Views](https://bigalorm.github.io/bigal/guide/views) — readonly models and ReadonlyRepository
-- [API Reference](https://bigalorm.github.io/bigal/reference/api) — all exports and method signatures
-- [Configuration](https://bigalorm.github.io/bigal/reference/configuration) — pools, read replicas, multi-database
-- [BigAl vs Raw SQL](https://bigalorm.github.io/bigal/advanced/bigal-vs-raw-sql) — decision framework
-- [Known Issues](https://bigalorm.github.io/bigal/advanced/known-issues) — workarounds and debugging
+- [Getting Started](https://bigalorm.github.io/bigal/getting-started) - install, first model, first query
+- [Models](https://bigalorm.github.io/bigal/guide/models) - decorators, column options, relationships
+- [Querying](https://bigalorm.github.io/bigal/guide/querying) - operators, pagination, JSONB, DISTINCT ON
+- [CRUD Operations](https://bigalorm.github.io/bigal/guide/crud-operations) - create, update, destroy, upserts
+- [Relationships](https://bigalorm.github.io/bigal/guide/relationships) - many-to-one, one-to-many, many-to-many, QueryResult
+- [Subqueries and Joins](https://bigalorm.github.io/bigal/guide/subqueries-and-joins) - subquery builder, aggregates, GROUP BY
+- [Views](https://bigalorm.github.io/bigal/guide/views) - readonly models and ReadonlyRepository
+- [API Reference](https://bigalorm.github.io/bigal/reference/api) - all exports and method signatures
+- [Configuration](https://bigalorm.github.io/bigal/reference/configuration) - pools, read replicas, multi-database
+- [BigAl vs Raw SQL](https://bigalorm.github.io/bigal/advanced/bigal-vs-raw-sql) - decision framework
+- [Known Issues](https://bigalorm.github.io/bigal/advanced/known-issues) - workarounds and debugging

--- a/skills/using-bigal/SKILL.md
+++ b/skills/using-bigal/SKILL.md
@@ -88,11 +88,12 @@ Use BigAl for the 90% of queries that fit its fluent API, and raw SQL for the re
 
 ### CRUD
 
-| SQL                                                         | BigAl                                          |
-| ----------------------------------------------------------- | ---------------------------------------------- |
-| `INSERT INTO products (name) VALUES ('Widget') RETURNING *` | `productRepo.create({ name: 'Widget' })`       |
-| `UPDATE products SET name = 'X' WHERE id = 1 RETURNING *`   | `productRepo.update({ id: 1 }, { name: 'X' })` |
-| `DELETE FROM products WHERE id = 1 RETURNING *`             | `productRepo.destroy({ id: 1 })`               |
+| SQL                                                         | BigAl                                                     |
+| ----------------------------------------------------------- | --------------------------------------------------------- |
+| `INSERT INTO products (name) VALUES ('Widget') RETURNING *` | `productRepo.create({ name: 'Widget' })`                  |
+| `UPDATE products SET name = 'X' WHERE id = 1 RETURNING *`   | `productRepo.update({ id: 1 }, { name: 'X' })`            |
+| `DELETE FROM products WHERE id = 1`                         | `productRepo.destroy({ id: 1 })`                          |
+| `DELETE FROM products WHERE id = 1 RETURNING *`             | `productRepo.destroy({ id: 1 }, { returnRecords: true })` |
 
 ### Subqueries, joins, and advanced
 
@@ -334,19 +335,38 @@ await productRepo.create({ name: 'Widget', priceCents: 999 }, { returnSelect: ['
 
 ### Update
 
+By default `update()` runs `RETURNING *` and hydrates the full updated rows.
+Shape what comes back to only what you need, or skip it entirely, to reduce bytes over the wire and hydration cost:
+
 ```ts
-// Returns array of updated records
+// Returns array of updated records (RETURNING *)
 const products = await productRepo.update({ id: 42 }, { name: 'Super Widget' });
 
 // Update multiple
 const products = await productRepo.update({ id: [42, 43] }, { priceCents: 1299 });
+
+// Return only specific columns (primary key always included) - smaller RETURNING clause, less to hydrate
+const products = await productRepo.update({ id: 42 }, { name: 'Super Widget' }, { returnSelect: ['name'] });
+
+// Skip returning records entirely (no RETURNING clause) - fastest when you do not need the rows back
+await productRepo.update({ id: 42 }, { name: 'Super Widget' }, { returnRecords: false });
 ```
 
 ### Destroy
 
+Unlike `create()`/`update()`, `destroy()` does not return records by default.
+It emits a plain `DELETE` with no `RETURNING` clause, which is the cheapest option.
+Opt in to the deleted rows only when you need them, and prefer `returnSelect` to bring back just the columns you use:
+
 ```ts
-// Returns array of deleted records
-const products = await productRepo.destroy({ id: 42 });
+// Default: deletes and resolves to void (no RETURNING clause)
+await productRepo.destroy({ id: 42 });
+
+// Opt in to the deleted rows (RETURNING *)
+const products = await productRepo.destroy({ id: 42 }, { returnRecords: true });
+
+// Return only specific columns (primary key always included) - returnSelect implies returnRecords
+const products = await productRepo.destroy({ id: 42 }, { returnSelect: ['name'] });
 ```
 
 ### Subqueries
@@ -451,6 +471,27 @@ type ProductSummary = Pick<QueryResult<Product>, 'id' | 'name' | 'store'>;
 type ProductSummaryWrong = Pick<Product, 'id' | 'name' | 'store'>;
 ```
 
+### Select only the columns you need
+
+`find()`/`findOne()` select every column by default. Pass `select` to return only the columns you actually use.
+This shrinks the SELECT list, reduces bytes transferred, and lowers hydration cost.
+For wide rows, large JSON blobs, or vector/embedding columns it can be a large win, since the database only reads and ships those columns when you ask for them.
+`populate()` and joined models accept the same `select` option:
+
+```ts
+// Selects every column
+const product = await productRepo.findOne().where({ id: 42 });
+
+// Selects only the primary key (always included) + name + priceCents
+const product = await productRepo.findOne({ select: ['name', 'priceCents'] }).where({ id: 42 });
+
+// Applies to lists, populated relations, and joins too
+const products = await productRepo
+  .find({ select: ['name'] })
+  .where({ store: storeId })
+  .populate('store', { select: ['name'] });
+```
+
 ### Prefer count() over findOne() for existence checks
 
 If you only need to know whether a match exists, use `count()` instead of `findOne()` — it performs better since it doesn't select or hydrate a row:
@@ -499,6 +540,7 @@ After applying this skill, verify:
 - [ ] JSON column types with `id` fields use `NotEntity<T>`
 - [ ] Model names in decorators are strings (`'Store'`) to avoid circular imports
 - [ ] `QueryResult<T>` is used for derived types involving relationships
+- [ ] Queries return only needed data: `select` on `find()`/`findOne()`/`populate()`, and `returnSelect` / `returnRecords: false` on `create()`/`update()`/`destroy()` when the full row is not needed
 
 ## Further Reading
 

--- a/skills/using-bigal/SKILL.md
+++ b/skills/using-bigal/SKILL.md
@@ -273,7 +273,16 @@ const product = await productRepo
 // product.store is the full Store entity
 ```
 
+`populate()` does not use a SQL `JOIN`.
+After the main query resolves, it runs a separate query per relation (batched by id, in parallel) and nests the results, so `.join()` is not needed to populate.
+Every primary row is returned whether or not the relation exists (an absent to-one is `undefined`, an empty to-many is `[]`).
+`populate`'s `where`/`limit` constrain only the related rows, not the primary results.
+Add `.join()` only when you need to filter or sort the primary results by a related table's columns.
+
 ### Joins
+
+Use `.join()`/`.leftJoin()` to constrain or sort the primary results by columns on a related table (or to join subquery aggregates), not to load related records.
+To load related records, use `.populate()` (above), which does not require a join.
 
 ```ts
 // Model join (INNER)


### PR DESCRIPTION
## Summary

Documentation and skill improvements around query data-shaping and relationship loading, plus a correctness fix for `destroy()`'s documented return behavior. Docs-only; no `src/` changes.

## What changed

### Data-shaping performance
- **`select` on `find()`/`findOne()`** - guidance that projecting only needed columns shrinks the SELECT list, cuts bytes over the wire, and lowers hydration cost (a large win for wide rows, big JSON, or vector/embedding columns). `populate()` and joined models take the same option.
- **`returnSelect` / `returnRecords` on `create()`/`update()`/`destroy()`** - the write-side equivalent: return only the columns you need, or skip the returned rows entirely.

### `destroy()` return behavior (correctness fix)
The skill, CRUD guide, and API reference all claimed `destroy()` returns deleted records by default. It does not: unlike `create()`/`update()` (which default to `RETURNING *`), `destroy()` emits a plain `DELETE` with no `RETURNING` and resolves to `void`. `returnRecords: true` / `returnSelect` opt into the deleted rows. Verified against `src/Repository.ts` (`returnRecords = options?.returnRecords ?? !!returnSelect`) and the destroy test asserting a bare `DELETE` resolving to `undefined`.

### `.populate()` vs `.join()`
Clarified that `.populate()` does not use a SQL `JOIN` - it runs a separate `find()` per relation after the main query (batched by id, in parallel) and nests the results, so `.join()` is not required to load relations. Every primary row is returned whether or not the relation exists (absent to-one is `undefined`, empty to-many is `[]`), and populate's `where`/`limit` constrain only the related rows. `.join()` is only for constraining/sorting the primary results by a related table's columns. Verified against `ReadonlyRepository.populateFields`.

### Style
Normalized em dashes to single hyphens across the docs and skill.

## Files
- `skills/using-bigal/SKILL.md`
- `docs/guide/querying.md`, `docs/guide/crud-operations.md`, `docs/guide/subqueries-and-joins.md`, `docs/guide/relationships.md`, `docs/guide/models.md`, `docs/guide/views.md`
- `docs/reference/api.md`, `docs/getting-started.md`, `docs/index.md`, `docs/advanced/known-issues.md`
- `README.md`

markdownlint passes on all edited files.