### PR TITLE
docs: document populate options and query builder methods

### DIFF
--- a/.agents/skills/no-ai-slop/SKILL.md
+++ b/.agents/skills/no-ai-slop/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: no-ai-slop
+description: Edit drafts into sharper, more human writing while preserving the writer's personal voice, or detect AI-slop patterns without rewriting. Use when the user wants a draft clearer, more direct, more opinionated, or less AI-sounding, or asks whether writing reads as AI.
+---
+
+# No AI slop
+
+You are a sharp human editor. Preserve the user's point and personal voice while making the writing clearer and more alive. Remove AI patterns without turning distinctive writing into generic polished prose.
+
+## Two jobs
+
+**Edit (default).** The user shares a draft to fix. Make the minimum effective edit with the rules below and return the edited draft plus a What changed section.
+
+**Detect.** The user asks whether a piece is AI slop, or asks to audit, scan, or flag a draft without rewriting. Name each pattern from this skill that appears, quote the line, and give the fix in a few words. Do not rewrite, score the draft, or guess whether AI wrote it. AI detectors guess. Named patterns are evidence the user can check. Offer to edit the draft after.
+
+## What to ask for
+
+If the user has not provided a draft, ask them to paste it.
+
+If the audience or format is unclear, ask one question: Who is this for and where will it be published?
+
+If the goal is unclear, ask what the reader should think, feel, or do after reading it.
+
+## Editing principles
+
+- **Preserve the writer's real voice.** First notice the draft's vocabulary, cadence, bluntness, humor, uncertainty, digressions, and level of polish. Keep the traits that feel personal to the writer. Do not make every paragraph equally tidy or rewrite distinctive lines merely for consistency.
+- **Make the minimum effective edit.** Fix AI patterns, errors, repetition, and unclear passages. Leave strong human sentences alone. A rough draft with a real voice should still sound like the same person after editing.
+- **Lead with the point when the setup adds nothing.** Cut generic throat-clearing. Keep a personal aside, story, or admission when it creates context, tension, or character.
+- **Front-load only when it improves clarity.** Put conclusions early when that helps the reader. Do not force every section and paragraph into the same point-detail-background shape.
+- **Keep the user's meaning.** Don't invent claims, examples, stats, or opinions. If something is unclear, ask.
+- **Open it up, don't dumb it down.** Keep the substance, nuance, and precision. Strip out only what makes it hard to read: jargon, long sentences, abstract nouns, and tangled structure.
+- **Use active voice.** "The team shipped it Tuesday" beats "the decision emerged." Never let inanimate things do human verbs.
+- **Make every sentence earn its place.** Cut empty qualifiers and throat-clearing. Keep phrases such as "I think," "maybe," or "to be honest" when they express real uncertainty, self-awareness, or the writer's spoken rhythm.
+- **Untangle sentences without flattening the cadence.** Split sentences and paragraphs when they are genuinely hard to follow. Keep longer spoken sentences, fragments, and changes in pace when they are clear and characteristic of the writer.
+- **Be concrete and specific.** Abstraction is where writing goes to die. "The integration improved efficiency" becomes "The integration cut deploy time from 40 minutes to 4." Names, numbers, dates, mechanisms, and examples beat abstractions.
+- **Use the portability test.** If a sentence could move unchanged to another person, company, country, or product, it is probably filler. Cut it or replace it with a fact, example, mechanism, consequence, or judgment specific to this subject.
+- **Always show, don't tell the reader what to think.** Make facts, actions, examples, and consequences carry the emphasis. Cut commentary that labels a point important, surprising, subtle, or obvious instead of demonstrating why. If the surrounding prose already shows the point, trust the reader and delete the commentary.
+- **Protect the specific fact.** Don't smooth a useful detail into generic importance. "The tool significantly improves engineering productivity" becomes "The tool cut review time from 30 minutes to 8."
+- **Make verbs do the work.** Replace weak verb phrases with direct verbs. "Made a decision" becomes "decided." "Has the ability to" becomes "can."
+- **Know the job.** Before structure or word choice, know what the piece is trying to do and who it is for.
+- **Preserve useful edge and character.** Keep strong opinions, blunt language, humor, profanity, self-interruptions, and honest admissions when they belong to the writer. Don't replace them with safer or more professional wording.
+- **Keep structure unless it's hurting the piece.** Preserve the writer's progression and detours when they carry personality. If you reorganize, say why in the What changed section.
+
+## Words to cut
+
+Banned outright: delve, foster, leverage, utilize, facilitate, empower, streamline, robust, cutting-edge, paradigm shift, game changer, this is huge, this changes everything, tapestry, realm, beacon, multifaceted, meticulous, intricate, paramount, transformative, elevate, embark, supercharge, harness, ever-evolving.
+
+Often-empty adverbs: just, literally, honestly, simply, actually, truly, fundamentally, importantly, crucially, inherently, inevitably. Cut them when they add nothing. Keep them when they carry emphasis, uncertainty, contrast, or the writer's natural spoken rhythm.
+
+Often-empty phrases: it's worth noting, it's important to note, at the end of the day, when it comes to, at its core, in today's world, in the age of, in the world of, the reality is, the truth is, in terms of, with regard to, in order to, going forward, in this article, let's dive in. Cut them when they delay the point. Keep an occasional phrase when it is part of the writer's recognizable voice and the sentence still earns its place.
+
+## Patterns to cut
+
+**Binary contrasts.** "This is not X. It's Y." / "The question isn't X, it's Y." / "It's not just X but Y." State Y directly. "The question isn't the model. It's the eval." becomes "The eval matters more than the model."
+
+**Throat-clearing openers.** "Here's the thing," "Here's what I mean," "Let me be clear," "I'll be honest," "The uncomfortable truth is." Cut them and state the point.
+
+**Faux-insight setups.** "This is the part most people skip," "What most people get wrong," "Here's what nobody tells you," "The part everyone misses." These flatter the writer as the lone expert. Cut the setup and make the claim stand on its own. "The part everyone misses: distribution is the real moat" becomes "Distribution is the moat."
+
+**Colon reveals.** A noun phrase, a colon, then a lowercase dramatic reveal: "The detail that makes it work: a separate agent grades it." "The best part: it learns." Rewrite as a plain sentence ("A separate agent does the grading, which is what makes it work"). Use colons for lists, labels, and quotes, not fake drama. Prefer sentence case after a colon unless grammar, a proper noun, a title, or code requires otherwise.
+
+**Superficial analysis.** Cut trailing `-ing` clauses that pretend to explain meaning: "highlighting," "underscoring," "reflecting," "showcasing." "The launch adds file search, highlighting the team's commitment to better workflows" becomes "The launch adds file search, so users can find old drafts without leaving the editor."
+
+**Importance puffery.** "Stands as a testament," "marks a pivotal moment," "plays a vital role," "solidifies its position," "underscores its significance." State the fact and let the reader judge whether it matters. "The launch marks a pivotal moment for the company" becomes "The launch is the company's first paid product."
+
+**Interpretive metadiscourse.** Cut lines that step outside the subject to tell the reader what to notice, how much weight to give it, or how to interpret the prose: "That last part matters more than it sounds," "The key point is," "As you can see," "This distinction matters," and redundant "In other words." If the point is clear, delete the aside. Otherwise, replace it with support or facts already in the content.
+
+**Weasel attribution.** "Experts agree," "industry reports suggest," "many argue," "widely regarded as," "studies show." Name the source or cut the claim. If the user has no source, ask instead of inventing one.
+
+**Fake-strong verbs.** Prefer "is" and "has" when they are clearer. "The app serves as a centralized hub for sponsor management" becomes "The app tracks sponsors, drafts, due dates, and approvals in one place."
+
+**Synonym cycling.** If the clear word is right, repeat it. Don't rotate terms for style. "The agent reviews the draft. The assistant scores the piece. The tool suggests fixes" becomes "The agent reviews the draft, scores it, and suggests fixes."
+
+**Negative listing.** "Not a X. Not a Y. A Z." Just say Z.
+
+**Dramatic fragmentation.** "X. And Y. And Z." or "That's it. That's the whole thing." Use complete sentences.
+
+**Robotic rhythm.** Avoid repeated sentence shapes, identical paragraph structures, and stacked punchy fragments. Vary the shape only when it helps the point.
+
+**Rhetorical setups.** "What if I told you...", "Think about it:", "Plot twist:", and self-answered "Question? Answer." pairs. Drop them and make the point.
+
+**Fake-profound kickers.** Cut the final "deep" line when it turns the point into a cute metaphor, aphorism, or mic-drop sentence. Do not rewrite it into a better metaphor. Do not preserve the rhythm. Delete it, then end on the clearest concrete sentence already in the draft. If the ending needs more closure, add a plain takeaway or next action.
+
+**Summary-recap endings.** "In conclusion," "Ultimately," "Overall," or a final paragraph that restates the piece. The reader was just there. End on the last concrete point, takeaway, or next action instead.
+
+**Formatting slop.** Emoji in headings, bold sprinkled mid-sentence for emphasis, bullet lists where two sentences of prose would read better, and headers over two-sentence sections. Format should follow the content, not decorate it.
+
+**Em dashes.** Do not use them as a default rhythm crutch. In short copy, use none. In longer drafts, 1-2 are fine if they clearly beat commas, periods, or parentheses. Remove clusters and decorative dashes.
+
+## Workflow
+
+1. Read the full draft before editing.
+2. Identify the core point and 3-5 voice signals to preserve, such as vocabulary, cadence, bluntness, humor, uncertainty, or digressions. Keep this note internal. If you cannot identify the core point, ask the user.
+3. For a detect request, return the findings report described in Two jobs and stop.
+4. For an edit, make the minimum effective changes, then check the edited draft against `eval.md` yourself.
+5. If any check fails, fix the draft and run the checks again.
+6. Output the full edited draft and a short **What changed** section.

--- a/.agents/skills/no-ai-slop/eval.md
+++ b/.agents/skills/no-ai-slop/eval.md
@@ -1,0 +1,44 @@
+# No AI slop eval
+
+Use this after the rewrite. Answer each check with pass or fail. If any check fails, fix the draft before returning it.
+
+For detect requests, make sure the response names each pattern found with a quoted line and a short fix, without rewriting the draft.
+
+## Editing principles
+
+1. Does the edit preserve the user's point without adding claims, examples, stats, quotes, or opinions?
+2. Does it preserve the writer's distinctive vocabulary, cadence, bluntness, humor, uncertainty, digressions, and level of polish?
+3. Does it leave strong human sentences alone instead of rewriting them for consistency or making every paragraph equally tidy?
+4. Is the amount of cutting proportional to the actual slop, with no aggressive compression that strips out character?
+5. Does the draft lead with what the reader needs while keeping personal setup that adds context, tension, or character?
+6. Are points front-loaded where that improves clarity without forcing every unit into the same structure?
+7. Do sentences earn their place, with concrete facts, protected details, and direct verbs where the draft supports them?
+8. Does every generic sentence pass the portability test, or was it cut or made specific to this subject?
+9. Does the draft use active voice with human subjects where possible?
+10. Does the edit keep useful edge and preserve structure unless the structure was hurting the piece?
+11. Are genuinely tangled sentences fixed while clear spoken cadence, fragments, and changes in pace remain intact?
+
+## Words to cut
+
+1. Are banned words, filler phrases, often-empty adverbs, and inflated claims removed unless quoted as examples?
+
+## Patterns to cut
+
+1. Are binary contrasts, negative listings, rhetorical setups, and throat-clearing openers removed?
+2. Are faux-insight setups, colon reveals, superficial analysis, fake-strong verbs, synonym cycling, dramatic fragments, and robotic rhythm fixed?
+3. Are importance puffery and weasel attribution replaced with plain facts and named sources, or flagged for the user when no source exists?
+4. Is interpretive metadiscourse removed, including authorial metacommentary, reader guidance, emphasis markers, and redundant glossing?
+5. Are fake-profound kicker lines deleted instead of rewritten into better metaphors?
+6. Are summary-recap endings cut so the piece ends on a concrete point, takeaway, or next action?
+7. Is formatting slop removed: Emoji headings, decorative bold, bullets that should be prose, headers over tiny sections?
+8. Are colons sentence case unless grammar, a proper noun, a title, or code requires otherwise?
+9. Are em dashes used sparingly: Usually none in short copy, and only 1-2 in longer drafts when they clearly help?
+
+## Final read
+
+1. Was the edit checked directly against this file without requiring separate editor and evaluator agents?
+2. Does the draft avoid robotic symmetry, repeated sentence shapes, and stacked punchy fragments?
+3. Would the writer recognize the edited draft as their own voice?
+4. Would the edited draft sound natural if read to a sharp colleague?
+5. Does the final output include the full edited draft and a short **What changed** section?
+6. For detect requests, does the response name each pattern with a quoted line and a short fix, without rewriting, scoring, or claiming AI authorship?

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,2 @@
 CHANGELOG.md
+.agents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,11 +71,12 @@ Repositories provide CRUD operations with type-safe query building:
 
 ### Query Building
 
-Queries use a fluent builder pattern with immutable state:
+Queries use a fluent builder pattern:
 
-- Each method returns a new instance (clone pattern)
+- Chained methods mutate the query's internal state and return the same instance (`return this`); type-narrowing methods like `.select()` and `.populate()` return the instance re-typed
 - Methods chain naturally: `.where({...}).sort('name').limit(10)`
 - Queries are `PromiseLike` for automatic execution
+- Each `find()`/`findOne()`/`count()` call creates a fresh query; do not branch one builder into multiple queries
 
 ### SQL Generation
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![node version](https://img.shields.io/node/v/bigal.svg?style=flat)](https://nodejs.org)
 [![Known Vulnerabilities](https://snyk.io/test/npm/bigal/badge.svg)](https://snyk.io/test/npm/bigal)
 
-A PostgreSQL-optimized, type-safe TypeScript ORM for Node.js. BigAl uses a fluent builder pattern for queries,
-decorator-based models, and immutable query state. Built exclusively for Postgres - queries are tuned for
+A PostgreSQL-optimized, type-safe TypeScript ORM for Node.js. BigAl uses a fluent builder pattern for queries
+and decorator-based models. Built exclusively for Postgres - queries are tuned for
 Postgres performance with native support for JSONB, DISTINCT ON, subquery joins, ON CONFLICT upserts, and pgvector.
 
 ## Install

--- a/docs/guide/querying.md
+++ b/docs/guide/querying.md
@@ -5,7 +5,9 @@ description: Fluent query builder for find, findOne, and count with WHERE operat
 # Querying
 
 BigAl provides `findOne()`, `find()`, and `count()` methods on repositories. Queries use a fluent builder pattern -
-each method returns a new immutable instance, and queries are `PromiseLike` so you can `await` them directly.
+chained methods build up one query object, and queries are `PromiseLike` so you can `await` the chain directly.
+Each call to `find()`, `findOne()`, or `count()` starts a fresh query. See the
+[API reference](/reference/api#query-builder-methods) for the full list of chainable methods.
 
 ## findOne
 
@@ -32,6 +34,15 @@ const product = await productRepository
 // find() takes the same option
 const products = await productRepository.find({ select: ['name', 'sku'] }).where({ store: storeId });
 ```
+
+`.select()` is also available as a chained method and narrows the result type to the picked columns:
+
+```ts
+const products = await productRepository.find().select(['name', 'sku']).where({ store: storeId });
+// products: Pick<QueryResult<Product>, 'name' | 'sku'>[]
+```
+
+The primary key column is always included in the generated SQL, even when it is not in the `select` list.
 
 ### Pool override
 
@@ -70,6 +81,9 @@ const exists = (await productRepository.count().where({ sku: 'ABC123' })) > 0;
 ```
 
 ## Where operators
+
+Calling `.where()` more than once replaces the previous filter - combine conditions in a single object
+instead. (`.sort()` is the opposite: repeated calls [append](#multiple-sort-calls).)
 
 ### String matching
 
@@ -213,16 +227,31 @@ await repo.find().where({
 
 ### String syntax
 
+Direction is `asc` or `desc` (case-insensitive) and defaults to ascending when omitted:
+
 ```ts
+await productRepository.find().where({}).sort('name'); // ASC
 await productRepository.find().where({}).sort('name asc');
 await productRepository.find().where({}).sort('name asc, createdAt desc');
 ```
 
 ### Object syntax
 
+Values can be `1`/`-1` or `'asc'`/`'desc'`:
+
 ```ts
 await productRepository.find().where({}).sort({ name: 1 }); // ASC
 await productRepository.find().where({}).sort({ name: 1, createdAt: -1 }); // ASC, DESC
+await productRepository.find().where({}).sort({ name: 'asc', createdAt: 'desc' }); // Same as above
+```
+
+### Multiple sort calls
+
+Repeated `.sort()` calls append sort columns instead of replacing them - these are equivalent:
+
+```ts
+await productRepository.find().sort('store').sort('createdAt desc');
+await productRepository.find().sort('store, createdAt desc');
 ```
 
 ## Vector distance queries
@@ -296,10 +325,12 @@ await productRepository.find().where({}).skip(20).limit(10);
 
 ### paginate
 
+`paginate({ page, limit })` is shorthand for `.skip((page - 1) * limit).limit(limit)`. `page` starts at 1;
+values below 1 are treated as page 1.
+
 ```ts
-const page = 2;
-const pageSize = 25;
-await productRepository.find().where({}).paginate(page, pageSize);
+await productRepository.find().where({}).paginate({ page: 2, limit: 25 });
+// SQL: ... LIMIT 25 OFFSET 25
 ```
 
 ### withCount
@@ -328,7 +359,9 @@ Requirements:
 
 ## Populate
 
-Load related entities:
+`populate(propertyName, options?)` loads related entities onto the results. It is available on `find()` and
+`findOne()` for any relationship defined with `model`, `collection`, or `through`
+(see [Relationships](/guide/relationships)):
 
 ```ts
 const product = await productRepository
@@ -347,9 +380,117 @@ The populate `where`/`limit` options constrain only the related rows, never the 
 Reach for [`.join()`](/guide/subqueries-and-joins#model-joins) only to constrain or sort the primary results by columns on the related table (for example, only products whose store is active).
 Without such a constraint, `.populate()` on its own is all you need.
 
+### Populate options
+
+All options are optional and apply to the query for related rows, never to the primary results:
+
+| Option    | Type                | Description                                                                                                            |
+| --------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `select`  | `string[]`          | Columns to return on the related entities. The primary key is always included.                                         |
+| `where`   | `WhereQuery`        | Filter related rows. Accepts the same operators as [`.where()`](#where-operators).                                     |
+| `sort`    | `string \| object`  | Order related rows. Same syntax as [`.sort()`](#sorting).                                                              |
+| `skip`    | `number`            | Skip related rows. Collections only.                                                                                   |
+| `limit`   | `number`            | Maximum related rows to return. Collections only.                                                                      |
+| `pool`    | `PoolLike`          | Connection pool for the populate query. Defaults to the main query's pool.                                             |
+| `through` | `{ where?, sort? }` | Filter and order by junction table columns. Many-to-many relations only. See [below](#many-to-many-through-relations). |
+
+### To-one relations
+
+For `model` relations, `where` acts as a condition on the related row - when the row does not match, the
+property is `undefined`. `skip` and `limit` are ignored.
+
+```ts
+const product = await productRepository
+  .findOne()
+  .where({ id: 42 })
+  .populate('store', {
+    select: ['name'],
+    where: { isActive: true },
+  });
+
+// product.store is the Store when it is active, otherwise undefined
+```
+
+### Collections
+
+For `collection` relations, every option applies to the related rows:
+
+```ts
+const store = await storeRepository
+  .findOne()
+  .where({ id: storeId })
+  .populate('products', {
+    select: ['name', 'sku'],
+    where: { status: 'available' },
+    sort: 'name asc',
+    limit: 10,
+  });
+
+// store.products has at most 10 available products, sorted by name
+```
+
+Two caveats when populating collections on `find()` (multiple primary rows):
+
+- BigAl fetches related rows for all primary rows in one query, so `limit` and `skip` apply to the combined
+  set, not per primary row. For "top N per parent", populate from `findOne()` or use a
+  [DISTINCT ON subquery join](/guide/subqueries-and-joins#distinct-on-in-subqueries).
+- A populate `select` must include the relation's `via` property (the foreign key back to the parent).
+  BigAl needs it to group rows by parent and throws if it is missing.
+
+### Many-to-many (through) relations
+
+For `through` relations, `through.where` filters junction rows and `through.sort` orders the populated items
+by junction table columns. Item order always follows the junction query, so use `through.sort` (not `sort`)
+to control ordering:
+
+```ts
+const product = await productRepository
+  .findOne()
+  .where({ id: productId })
+  .populate('categories', {
+    select: ['name'],
+    where: { isActive: true }, // filters categories
+    through: {
+      where: { isPrimary: true }, // filters junction rows
+      sort: 'ordering asc', // orders items by a junction column
+    },
+  });
+```
+
+### Populating multiple relations
+
+Chain `.populate()` once per relation. The populate queries run in parallel:
+
+```ts
+const product = await productRepository
+  .findOne()
+  .where({ id: 42 })
+  .populate('store', { select: ['name'] })
+  .populate('categories', { through: { sort: 'ordering asc' } });
+```
+
+### Populate with a narrowed select
+
+`populate()` adds the relation's foreign key column to an earlier `.select()` automatically. Call `.select()`
+before `.populate()` - a later `.select()` replaces the column list and can drop the foreign key the populate
+needs:
+
+```ts
+const products = await productRepository
+  .find()
+  .select(['name'])
+  .populate('store', { select: ['name'] });
+```
+
+### Type narrowing
+
+`.populate()` changes the property's result type from the foreign key to the populated entity, narrowed by
+the populate `select` when one is given. Use `QueryResultPopulated<T, K>` to name these types - see
+[Relationships > QueryResultPopulated](/guide/relationships#queryresultpopulated).
+
 ## toJSON
 
-Return plain objects without class prototypes:
+Return plain objects without class prototypes. Populated relations are plain objects too:
 
 ```ts
 const product = await productRepository.findOne().where({ id: 42 }).toJSON();

--- a/docs/guide/relationships.md
+++ b/docs/guide/relationships.md
@@ -201,9 +201,12 @@ const compilation = await compilationRepository
   });
 ```
 
-- `through.where` filters junction table records
+- `through.where` filters junction table records; `where` filters the target entities themselves
 - `through.sort` orders populated items by junction table columns
-- When `through.sort` is specified, it takes precedence over the target entity sort
+- Item order always follows the junction query, so use `through.sort` (not `sort`) to control ordering of
+  many-to-many results
+
+See [Querying > Populate](/guide/querying#populate) for the full list of populate options.
 
 ## Best practices
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ features:
   - title: PostgreSQL-native
     details: Built exclusively for Postgres, not a lowest-common-denominator abstraction. Queries are tuned for Postgres performance. JSONB, DISTINCT ON, subquery joins, and ON CONFLICT upserts work out of the box.
   - title: Fluent builder pattern
-    details: Chain .where(), .sort(), .limit(), .join(), and .populate() calls. Each method returns a new immutable instance.
+    details: Chain .where(), .sort(), .limit(), .join(), and .populate() calls. Queries are PromiseLike - build the chain, then await it.
   - title: Decorator-based models
     details: Define tables, columns, and relationships with TypeScript decorators. Inheritance and schema support built in.
   - title: Type-safe queries

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -99,21 +99,204 @@ Read-only repository returned for models with `readonly: true`. Exposes `find()`
 
 ## Query builder methods
 
-All query types support fluent chaining. Each method returns a new immutable instance.
+All query types support fluent chaining. Chained methods build up a single query object, which executes when
+awaited. Each call to `find()`, `findOne()`, or `count()` starts a fresh query.
 
-| Method                             | Available on         | Description                      |
-| ---------------------------------- | -------------------- | -------------------------------- |
-| `.where(query)`                    | find, findOne, count | Filter records                   |
-| `.sort(value)`                     | find, findOne        | Order results                    |
-| `.limit(n)`                        | find                 | Limit rows returned              |
-| `.skip(n)`                         | find                 | Skip rows                        |
-| `.paginate(page, pageSize)`        | find                 | Shorthand for skip + limit       |
-| `.withCount()`                     | find                 | Return `{ results, totalCount }` |
-| `.populate(relation, options?)`    | find, findOne        | Load related entities            |
-| `.join(relation, alias?, on?)`     | find, findOne        | INNER JOIN                       |
-| `.leftJoin(relation, alias?, on?)` | find, findOne        | LEFT JOIN                        |
-| `.distinctOn(columns)`             | find                 | PostgreSQL DISTINCT ON           |
-| `.toJSON()`                        | find, findOne        | Return plain objects             |
+| Method                                 | Available on         | Description                      |
+| -------------------------------------- | -------------------- | -------------------------------- |
+| `.where(query)`                        | find, findOne, count | Filter records                   |
+| `.select(columns)`                     | find, findOne        | Narrow returned columns          |
+| `.sort(value)`                         | find, findOne        | Order results                    |
+| `.limit(n)`                            | find                 | Limit rows returned              |
+| `.skip(n)`                             | find                 | Skip rows                        |
+| `.paginate({ page, limit })`           | find                 | Shorthand for skip + limit       |
+| `.withCount()`                         | find                 | Return `{ results, totalCount }` |
+| `.populate(propertyName, options?)`    | find, findOne        | Load related entities            |
+| `.join(propertyName, alias?)`          | find, findOne        | INNER JOIN                       |
+| `.leftJoin(propertyName, alias?, on?)` | find, findOne        | LEFT JOIN                        |
+| `.distinctOn(columns)`                 | find                 | PostgreSQL DISTINCT ON           |
+| `.toJSON()`                            | find, findOne        | Return plain objects             |
+| `.UNSAFE_withOriginalFieldType(name)`  | find, findOne        | Type-level escape hatch          |
+| `.UNSAFE_withFieldValue(name, value)`  | findOne              | Set a field after the query      |
+
+### where()
+
+```ts
+query.where(whereQuery);
+```
+
+Filter records. Calling `.where()` again replaces the previous filter, so combine conditions in one object.
+See [Querying > Where operators](/guide/querying#where-operators) for the operator syntax.
+
+```ts
+await productRepository.find().where({ price: { '>=': 100 }, store: storeId });
+```
+
+### select()
+
+```ts
+query.select(columns);
+```
+
+Narrow the returned columns; the result type narrows to the picked keys. Equivalent to the `select` option on
+`find()`/`findOne()`. The primary key column is always included in the generated SQL.
+
+```ts
+const products = await productRepository.find().select(['name', 'sku']);
+// products: Pick<QueryResult<Product>, 'name' | 'sku'>[]
+```
+
+### sort()
+
+```ts
+query.sort(value);
+```
+
+Order results. Accepts a string (`'name'`, `'name asc'`, `'name asc, createdAt desc'`) or an object
+(`{ name: 1, createdAt: -1 }`, with `1`/`'asc'` and `-1`/`'desc'`). Direction defaults to ascending.
+Repeated `.sort()` calls append sort columns. Vector columns accept `{ nearestTo, metric }` - see
+[Querying > Vector distance queries](/guide/querying#vector-distance-queries).
+
+```ts
+await productRepository.find().sort('store').sort('createdAt desc');
+// Same as .sort('store, createdAt desc')
+```
+
+### limit() / skip()
+
+```ts
+query.limit(count);
+query.skip(count);
+```
+
+`LIMIT` and `OFFSET` for the query.
+
+### paginate()
+
+```ts
+query.paginate({ page, limit });
+```
+
+Shorthand for `.skip((page - 1) * limit).limit(limit)`. `page` starts at 1; values below 1 are treated as
+page 1.
+
+```ts
+await productRepository.find().where({ store: storeId }).paginate({ page: 2, limit: 25 });
+// SQL: ... LIMIT 25 OFFSET 25
+```
+
+### withCount()
+
+```ts
+query.withCount();
+```
+
+Resolves to `{ results, totalCount }` in a single query using `COUNT(*) OVER()`. `totalCount` is the number
+of rows matching the where clause, ignoring `limit`/`skip`. Throws when combined with `.distinctOn()`.
+
+```ts
+const { results, totalCount } = await productRepository.find().where({ store: storeId }).paginate({ page: 1, limit: 10 }).withCount();
+```
+
+### populate()
+
+```ts
+query.populate(propertyName, options?)
+```
+
+Load related entities. Runs a separate query per relation after the main query resolves (batched by id - no
+SQL `JOIN`) and changes the property's result type from foreign key to populated entity. Chain once per
+relation; the populate queries run in parallel.
+
+**Options:** `PopulateArgs`
+
+| Option    | Type                | Description                                                                    |
+| --------- | ------------------- | ------------------------------------------------------------------------------ |
+| `select`  | `string[]`          | Columns to return on the related entities. The primary key is always included. |
+| `where`   | `WhereQuery`        | Filter related rows.                                                           |
+| `sort`    | `string \| object`  | Order related rows. Same syntax as `.sort()`.                                  |
+| `skip`    | `number`            | Skip related rows. Collections only.                                           |
+| `limit`   | `number`            | Maximum related rows to return. Collections only.                              |
+| `pool`    | `PoolLike`          | Connection pool for the populate query. Defaults to the main query's pool.     |
+| `through` | `{ where?, sort? }` | Filter and order by junction table columns. Many-to-many relations only.       |
+
+Options apply to the related rows only, never to the primary results. See
+[Querying > Populate](/guide/querying#populate) for per-relation behavior and caveats.
+
+```ts
+const product = await productRepository
+  .findOne()
+  .where({ id: 42 })
+  .populate('store', { select: ['name'] })
+  .populate('categories', { where: { isActive: true }, through: { sort: 'ordering asc' } });
+```
+
+### join() / leftJoin()
+
+```ts
+query.join(propertyName, alias?)
+query.leftJoin(propertyName, alias?, on?)
+query.join(subquery, alias, { on })       // find only
+query.leftJoin(subquery, alias, { on })   // find only
+```
+
+Add an `INNER JOIN` or `LEFT JOIN` to the main query so `.where()` and `.sort()` can reference joined
+columns (`.where({ alias: { column: value } })`, `.sort('alias.column desc')`). Joins do not hydrate related
+entities - use `.populate()` for that. Subquery joins are available on `find()` only. See
+[Subqueries and Joins](/guide/subqueries-and-joins#model-joins).
+
+```ts
+const products = await productRepository
+  .find()
+  .join('store')
+  .where({ store: { name: 'Acme' } });
+```
+
+### distinctOn()
+
+```ts
+query.distinctOn(columns);
+```
+
+PostgreSQL `DISTINCT ON` - one row per unique combination of the given columns. The `ORDER BY` must start
+with the same columns in the same order, and `.distinctOn()` cannot be combined with `.withCount()`. See
+[Querying > DISTINCT ON](/guide/querying#distinct-on).
+
+```ts
+const latestPerStore = await productRepository.find().distinctOn(['store']).sort('store').sort('createdAt desc');
+```
+
+### toJSON()
+
+```ts
+query.toJSON();
+```
+
+Return plain objects instead of entity class instances, including populated relations. Useful when results
+must be serializable.
+
+```ts
+const product = await productRepository.findOne().where({ id: 42 }).populate('store').toJSON();
+```
+
+### UNSAFE_withOriginalFieldType()
+
+```ts
+query.UNSAFE_withOriginalFieldType(propertyName);
+```
+
+Type-level escape hatch with no runtime effect: restores a relation property's original entity type (for
+example `number | Store` instead of the narrowed `number`). Prefer `.populate()` or
+`QueryResultPopulated<T, K>` when possible.
+
+### UNSAFE_withFieldValue()
+
+```ts
+findOneQuery.UNSAFE_withFieldValue(propertyName, value);
+```
+
+`findOne()` only. Sets the property to the given value after the query resolves and types the result
+accordingly. The value is applied in memory - nothing is written to the database.
 
 ## subquery()
 

--- a/skills/using-bigal/SKILL.md
+++ b/skills/using-bigal/SKILL.md
@@ -193,7 +193,7 @@ class ProductSummary extends Entity {
 
 ### Fluent builder
 
-Every query method returns a new immutable instance. Queries are `PromiseLike` - just `await` the chain.
+Chained methods build up one query object. Queries are `PromiseLike` - just `await` the chain.
 
 ```ts
 // Find multiple
@@ -255,8 +255,8 @@ const count = await productRepo.count().where({ sku: { '!': null } });
 // Manual
 .skip(20).limit(10)
 
-// Shorthand
-.paginate(2, 25)   // page 2, 25 per page
+// Shorthand - page starts at 1
+.paginate({ page: 2, limit: 25 })
 
 // With total count (single query using COUNT(*) OVER())
 const { results, totalCount } = await productRepo
@@ -278,6 +278,27 @@ After the main query resolves, it runs a separate query per relation (batched by
 Every primary row is returned whether or not the relation exists (an absent to-one is `undefined`, an empty to-many is `[]`).
 `populate`'s `where`/`limit` constrain only the related rows, not the primary results.
 Add `.join()` only when you need to filter or sort the primary results by a related table's columns.
+
+Options: `select` (columns on related entities; primary key always included), `where` (filter related rows),
+`sort` (order related rows), `skip`/`limit` (collections only), `pool` (pool override), and `through`
+(`{ where?, sort? }` on the junction table, many-to-many only; item order follows the junction query, so use
+`through.sort` to order many-to-many results).
+
+```ts
+const store = await storeRepo
+  .findOne()
+  .where({ id: storeId })
+  .populate('products', {
+    select: ['name', 'sku'],
+    where: { status: 'available' },
+    sort: 'name asc',
+    limit: 10,
+  });
+```
+
+Caveats when populating collections on `find()` (multiple primary rows): `limit`/`skip` apply to the combined
+related-row query, not per primary row, and a populate `select` must include the relation's `via` property or
+BigAl throws.
 
 ### Joins
 
@@ -450,20 +471,21 @@ interface IMyJsonType {
 public metadata?: NotEntity<IMyJsonType>;
 ```
 
-### Query state is immutable
+### Query builders share state
 
-Each fluent method returns a new instance. Do not ignore the return value:
+Chained methods mutate the query's internal state and return the same instance. Build one chain per query
+and use the return value - type-narrowing methods like `.select()` and `.populate()` change the result type
+only through their return value:
 
 ```ts
-// Correct
-const query = productRepo.find().where({ store: storeId });
-const sorted = query.sort('name asc');
-const results = await sorted.limit(10);
+// Correct - one chain per query
+const results = await productRepo.find().where({ store: storeId }).sort('name asc').limit(10);
 
-// Wrong - .sort() result is discarded
-const query = productRepo.find().where({ store: storeId });
-query.sort('name asc'); // This does nothing to `query`
-const results = await query;
+// Wrong - both "branches" are the same object; sorts accumulate and the
+// second .where() replaces the first
+const base = productRepo.find().where({ store: storeId });
+const byName = base.sort('name asc');
+const byDate = base.sort('createdAt desc').where({ status: 'active' });
 ```
 
 ### QueryResult narrows relationship types
@@ -544,7 +566,7 @@ After applying this skill, verify:
 - [ ] Queries use the fluent builder pattern (not raw SQL strings)
 - [ ] CRUD uses Repository methods: `create()`, `update()`, `destroy()`
 - [ ] Query chains are awaited (not fire-and-forget)
-- [ ] Query state is treated as immutable (return values are used)
+- [ ] Each query is built as a single chain (builders are not branched into multiple queries)
 - [ ] Collection properties are optional (`?`)
 - [ ] JSON column types with `id` fields use `NotEntity<T>`
 - [ ] Model names in decorators are strings (`'Store'`) to avoid circular imports


### PR DESCRIPTION
Documents all populate options and every query builder method, and fixes two factual errors found while verifying the docs against the source.

## What changed

- **Populate reference** (`docs/guide/querying.md`): full options table (`select`, `where`, `sort`, `skip`, `limit`, `pool`, `through`) with per-relation behavior - to-one `where` semantics, collection batching caveats (`limit`/`skip` apply to the combined set on `find()`, populate `select` must include `via`), junction ordering for many-to-many, parallel populates, and the select-before-populate ordering trap.
- **API reference** (`docs/reference/api.md`): per-method docs for all query builder methods with signatures and examples, including the previously undocumented `.select()`, `.UNSAFE_withOriginalFieldType()`, and `.UNSAFE_withFieldValue()`.
- **Consumer skill** (`skills/using-bigal/SKILL.md`): same corrections plus a compact populate options summary.

## Fixes

- `.paginate(page, pageSize)` does not exist - the signature is `.paginate({ page, limit })` (`ReadonlyRepository.ts`). The old examples would not type-check.
- The docs claimed each chained method 'returns a new immutable instance'. Methods mutate the query's internal state and return `this`, so `query.sort(...)` does affect `query` and branching one builder produces cross-contaminated queries. Corrected in the docs, README, landing page, SKILL.md, and CLAUDE.md, with the real gotcha (don't branch builders) documented instead.

Docs build passes with no dead links; markdownlint clean.